### PR TITLE
Tuc range refactoring

### DIFF
--- a/src/bin/tuc.rs
+++ b/src/bin/tuc.rs
@@ -584,4 +584,28 @@ mod tests {
         assert_eq!(complement_std_range(2, &(0..1)), vec![1..2]);
         assert_eq!(complement_std_range(2, &(1..2)), vec![0..1]);
     }
+
+    #[test]
+    fn test_range_formatting() {
+        assert_eq!(
+            Range::new(Side::Continue, Side::Continue).to_string(),
+            "1:-1"
+        );
+        assert_eq!(
+            Range::new(Side::Continue, Side::Some(3)).to_string(),
+            ":3"
+        );
+        assert_eq!(
+            Range::new(Side::Some(3), Side::Continue).to_string(),
+            "3:"
+        );
+        assert_eq!(
+            Range::new(Side::Some(1), Side::Some(2)).to_string(),
+            "1:2"
+        );
+        assert_eq!(
+            Range::new(Side::Some(-1), Side::Some(-2)).to_string(),
+            "-1:-2"
+        );
+    }
 }

--- a/src/bin/tuc.rs
+++ b/src/bin/tuc.rs
@@ -184,11 +184,10 @@ struct Range {
 
 impl fmt::Display for Range {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if self.l == self.r {
-            // note that Side::Continue, Side::Continue is not expected
-            write!(f, "{}", self.l)
-        } else {
-            write!(f, "{}:{}", self.l, self.r)
+        match (self.l, self.r) {
+            (Side::Continue, Side::Continue) => write!(f, "1:-1"),
+            (l, r) if l == r => write!(f, "{}", l),
+            (l, r) => write!(f, "{}:{}", l, r),
         }
     }
 }

--- a/src/bin/tuc.rs
+++ b/src/bin/tuc.rs
@@ -305,7 +305,7 @@ fn get_fields_as_ranges<'a>(
     line: &str,
     delimiter: &str,
 ) -> &'a mut Vec<std::ops::Range<usize>> {
-    let delimiter_lenth = delimiter.len();
+    let delimiter_length = delimiter.len();
     let mut next_part_start = 0;
 
     for mat in line.match_indices(&delimiter) {
@@ -313,7 +313,7 @@ fn get_fields_as_ranges<'a>(
             start: next_part_start,
             end: mat.0,
         });
-        next_part_start = mat.0 + delimiter_lenth;
+        next_part_start = mat.0 + delimiter_length;
     }
 
     fields_as_ranges.push(std::ops::Range {


### PR DESCRIPTION
The internal `Range` struct is confusing to reason about when `std::ops::Range` are involved. `fields` is similarly confusing now that we cut on characters and bytes too.

Rename `Range` into `UserBounds`
Rename `fields_as_ranges` into `bounds_as_ranges`