### PR TITLE
README: add MacPorts install info

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ or run
 cargo install tuc # append `--features regex` if you want regex support
 ```
 
+Community-Managed Packages:
+
+- [MacPorts](https://www.macports.org/) (on macOS):
+  ```sh
+  sudo port install tuc
+  ```
+
 ## Help
 
 ```

--- a/README.md
+++ b/README.md
@@ -19,12 +19,7 @@ or run
 cargo install tuc # append `--features regex` if you want regex support
 ```
 
-Community-Managed Packages:
-
-- [MacPorts](https://www.macports.org/) (on macOS):
-  ```sh
-  sudo port install tuc
-  ```
+For other installation methods, check below the [community managed packages](#community-managed-packages)
 
 ## Help
 
@@ -198,6 +193,13 @@ ac
 ❯ echo "a b c" | tuc --complement -d ' ' -f 2
 ac
 ```
+
+## Community-Managed Packages
+
+- [MacPorts](https://www.macports.org/) (on macOS):
+  ```sh
+  sudo port install tuc
+  ```
 
 ## LICENSE
 


### PR DESCRIPTION
`tuc` is now available via MacPorts: https://ports.macports.org/port/tuc/