### PR TITLE
Disable unnecessary regex features to reduce binary size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+- feat: smaller binaries by removing unnecessary (to us) regex features
+
 ## [0.11.0] - 2022-06-20
 
 - fix: --lines could throw out of bounds with -f 1: in some situations

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 3
 
 [[package]]
-name = "aho-corasick"
-version = "0.7.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -126,8 +117,6 @@ version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
 dependencies = [
- "aho-corasick",
- "memchr",
  "regex-syntax",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["command-line-utilities"]
 [dependencies]
 anyhow = "1.0.58"
 pico-args = { version = "0.5.0", features = ["short-space-opt", "combined-flags", "eq-separator"] }
-regex = { version = "1.5", optional = true }
+regex = { version = "1.5", default-features = false, features = ["std"], optional = true }
 
 [features]
 default = []


### PR DESCRIPTION
This will reduce the size of the tuc binary built with regex feature by 54 %.

x86_64-alpine-linux-musl target:

* with full regex: 1.3 MiB
* with regex w/o default features: 602 kiB
* without regex: 350 kiB