### PR TITLE
Missing regex should display correct error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+- doc: README, man, --help now mention that --regex requires an argument
+- fix: --regex display the correct error message when argument is missing
+
+## [1.0.0] - 2023-02-25
+
 - feat: smaller binaries by removing unnecessary (to us) regex features
 - feat: regex cargo feature is enabled by default
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ OPTIONS:
                                   Implies --join. To merge lines, use --no-join
     -d, --delimiter <delimiter>   Delimiter used by --fields to cut the text
                                   [default: \t]
-    -e, --regex                   Use a regular expression as delimiter
+    -e, --regex <some regex>      Use a regular expression as delimiter
     -r, --replace-delimiter <new> Replace the delimiter with the provided text
     -t, --trim <type>             Trim the delimiter (greedy). Valid values are
                                   (l|L)eft, (r|R)ight, (b|B)oth

--- a/doc/tuc.1
+++ b/doc/tuc.1
@@ -135,6 +135,12 @@ To merge lines, use \[en]no-join
 .PD
 \ \ \ \ \ \ \ [default: \[rs]t]
 .PP
+\f[B]-e\f[R], \f[B]\[en]regex\f[R] [some regex]
+.PD 0
+.P
+.PD
+\ \ \ \ \ \ \ Use a regular expression as delimiter
+.PP
 \f[B]-r\f[R], \f[B]\[en]replace-delimiter\f[R] [new delimiter]
 .PD 0
 .P

--- a/doc/tuc.1.md
+++ b/doc/tuc.1.md
@@ -88,6 +88,9 @@ OPTIONS
 |        Delimiter used by --fields to cut the text
 |        [default: \\t]
 
+| **-e**, **--regex** [some regex]
+|        Use a regular expression as delimiter
+
 | **-r**, **--replace-delimiter** [new delimiter]
 |        Replace the delimiter with the provided text
 

--- a/src/bin/tuc.rs
+++ b/src/bin/tuc.rs
@@ -63,7 +63,7 @@ OPTIONS:
                                   Implies --join. To merge lines, use --no-join
     -d, --delimiter <delimiter>   Delimiter used by --fields to cut the text
                                   [default: \t]
-    -e, --regex                   Use a regular expression as delimiter
+    -e, --regex <some regex>      Use a regular expression as delimiter
     -r, --replace-delimiter <new> Replace the delimiter with the provided text
     -t, --trim <type>             Trim the delimiter (greedy). Valid values are
                                   (l|L)eft, (r|R)ight, (b|B)oth

--- a/src/bin/tuc.rs
+++ b/src/bin/tuc.rs
@@ -127,21 +127,18 @@ fn parse_args() -> Result<Opt, pico_args::Error> {
     let regex_bag = None;
 
     #[cfg(feature = "regex")]
-    let regex_bag: Option<RegexBag> =
-        if let Ok(Some(regex_text)) = pargs.opt_value_from_str::<_, String>(["-e", "--regex"]) {
-            Some(RegexBag {
-                normal: Regex::new(&regex_text).unwrap_or_else(|e| {
-                    eprintln!("tuc: runtime error. The regular expression is malformed. {e}");
-                    std::process::exit(1);
-                }),
-                greedy: Regex::new(&format!("({})+", &regex_text)).unwrap_or_else(|e| {
-                    eprintln!("tuc: runtime error. The regular expression is malformed. {e}");
-                    std::process::exit(1);
-                }),
-            })
-        } else {
-            None
-        };
+    let regex_bag: Option<RegexBag> = pargs
+        .opt_value_from_str::<_, String>(["-e", "--regex"])?
+        .map(|regex_text| RegexBag {
+            normal: Regex::new(&regex_text).unwrap_or_else(|e| {
+                eprintln!("tuc: runtime error. The regular expression is malformed. {e}");
+                std::process::exit(1);
+            }),
+            greedy: Regex::new(&format!("({})+", &regex_text)).unwrap_or_else(|e| {
+                eprintln!("tuc: runtime error. The regular expression is malformed. {e}");
+                std::process::exit(1);
+            }),
+        });
 
     if regex_bag.is_some() && !cfg!(feature = "regex") {
         eprintln!("tuc: runtime error. This version of tuc was compiled without regex support");


### PR DESCRIPTION
Fixes issue https://github.com/riquito/tuc/issues/87

- [x] updated README, man, --help by mentioning that -e/--regex requires an argument
- [x] `-e/--regex` display the proper error message when its argument is missing

When the argument is missing now the output is `Error: the '-e' option doesn't have an associated value` (same as for `-d` and others)