### PR TITLE
Fast lane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+- feat: much faster (3x) implementation for common scenarios
+
 ## [1.2.0] - 2024-01-01
 
 - feat: new option --json to format output as JSON array

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,13 +40,12 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.1.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45ea9b00a7b3f2988e9a65ad3917e62123c38dba709b666506207be96d1790b"
+checksum = "c48f0051a4b4c5e0b6d365cd04af53aeaa209e3cc15ec2cdb69e73cc87fbd0dc"
 dependencies = [
  "memchr",
- "once_cell",
- "regex-automata 0.1.10",
+ "regex-automata",
  "serde",
 ]
 
@@ -70,15 +69,9 @@ checksum = "12b8adadd720df158f4d70dfe7ccc6adb0472d7c55ca83445f6a5ab3e36f8fb6"
 
 [[package]]
 name = "memchr"
-version = "2.6.4"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
-
-[[package]]
-name = "once_cell"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "pico-args"
@@ -121,15 +114,9 @@ checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.5",
+ "regex-automata",
  "regex-syntax",
 ]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-automata"
@@ -166,6 +153,8 @@ version = "1.2.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "bstr",
+ "memchr",
  "pico-args",
  "predicates",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ categories = ["command-line-utilities"]
 
 [dependencies]
 anyhow = "1.0.79"
+bstr = "1.9.0"
+memchr = "2.7.1"
 pico-args = { version = "0.5.0", features = ["short-space-opt", "combined-flags", "eq-separator"] }
 regex = { version = "1.10", default-features = false, features = ["std", "unicode-bool", "unicode-perl", "unicode-gencat"], optional = true }
 

--- a/src/bin/tuc.rs
+++ b/src/bin/tuc.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use std::convert::{TryFrom, TryInto};
+use std::convert::TryFrom;
 use std::io::Write;
 use std::str::FromStr;
 use tuc::bounds::{BoundOrFiller, BoundsType, UserBoundsList};

--- a/src/bin/tuc.rs
+++ b/src/bin/tuc.rs
@@ -259,8 +259,8 @@ fn parse_args() -> Result<Opt, pico_args::Error> {
 fn main() -> Result<()> {
     let opt: Opt = parse_args()?;
 
-    let mut stdin = std::io::BufReader::new(std::io::stdin().lock());
-    let mut stdout = std::io::BufWriter::new(std::io::stdout().lock());
+    let mut stdin = std::io::BufReader::with_capacity(64 * 1024, std::io::stdin().lock());
+    let mut stdout = std::io::BufWriter::with_capacity(64 * 1024, std::io::stdout().lock());
 
     if opt.bounds_type == BoundsType::Bytes {
         read_and_cut_bytes(&mut stdin, &mut stdout, &opt)?;

--- a/src/bin/tuc.rs
+++ b/src/bin/tuc.rs
@@ -1,10 +1,12 @@
 use anyhow::Result;
+use std::convert::{TryFrom, TryInto};
 use std::io::Write;
 use std::str::FromStr;
 use tuc::bounds::{BoundOrFiller, BoundsType, UserBoundsList};
 use tuc::cut_bytes::read_and_cut_bytes;
 use tuc::cut_lines::read_and_cut_lines;
 use tuc::cut_str::read_and_cut_str;
+use tuc::fast_lane::{read_and_cut_text_as_bytes, FastOpt};
 use tuc::options::{Opt, EOL};
 
 #[cfg(feature = "regex")]
@@ -264,6 +266,8 @@ fn main() -> Result<()> {
         read_and_cut_bytes(&mut stdin, &mut stdout, &opt)?;
     } else if opt.bounds_type == BoundsType::Lines {
         read_and_cut_lines(&mut stdin, &mut stdout, &opt)?;
+    } else if let Ok(fast_opt) = FastOpt::try_from(&opt) {
+        read_and_cut_text_as_bytes(&mut stdin, &mut stdout, &fast_opt)?;
     } else {
         read_and_cut_str(&mut stdin, &mut stdout, opt)?;
     }

--- a/src/bounds.rs
+++ b/src/bounds.rs
@@ -327,6 +327,7 @@ impl UserBounds {
      *
      * Fields are 1-indexed.
      */
+    #[inline(always)]
     pub fn matches(&self, idx: i32) -> Result<bool> {
         match (self.l, self.r) {
             (Side::Some(left), _) if (left * idx).is_negative() => {

--- a/src/bounds.rs
+++ b/src/bounds.rs
@@ -2,10 +2,10 @@ use anyhow::{bail, Result};
 use std::cmp::Ordering;
 use std::convert::TryInto;
 use std::fmt;
-use std::ops::Range;
+use std::ops::{Deref, Range};
 use std::str::FromStr;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, PartialEq)]
 pub enum BoundsType {
     Bytes,
     Characters,
@@ -13,7 +13,7 @@ pub enum BoundsType {
     Lines,
 }
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum BoundOrFiller {
     Bound(UserBounds),
     Filler(String),
@@ -97,6 +97,14 @@ pub fn parse_bounds_list(s: &str) -> Result<Vec<BoundOrFiller>> {
 
 #[derive(Debug)]
 pub struct UserBoundsList(pub Vec<BoundOrFiller>);
+
+impl Deref for UserBoundsList {
+    type Target = Vec<BoundOrFiller>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 impl FromStr for UserBoundsList {
     type Err = anyhow::Error;
@@ -287,11 +295,13 @@ impl UserBounds {
         UserBounds { l, r }
     }
     /**
-     * Check if an index is between the bounds.
+     * Check if a field is between the bounds.
      *
      * It errors out if the index has different sign than the bounds
      * (we can't verify if e.g. -1 idx is between 3:5 without knowing the number
      * of matching bounds).
+     *
+     * Fields are 1-indexed.
      */
     pub fn matches(&self, idx: i32) -> Result<bool> {
         match (self.l, self.r) {

--- a/src/bounds.rs
+++ b/src/bounds.rs
@@ -117,7 +117,7 @@ impl UserBoundsList {
     /// Detect whether the list can be sorted.
     /// It can be sorted only if every bound
     /// has the same sign (all positive or all negative).
-    fn is_sortable(&self) -> bool {
+    pub fn is_sortable(&self) -> bool {
         let mut has_positive_idx = false;
         let mut has_negative_idx = false;
         self.get_userbounds_only().for_each(|b| {

--- a/src/bounds.rs
+++ b/src/bounds.rs
@@ -338,14 +338,18 @@ impl UserBounds {
     /// e.g.
     ///
     /// ```rust
+    /// # use tuc::bounds::UserBounds;
+    /// # use std::ops::Range;
+    /// # use tuc::bounds::Side;
+    ///
     /// assert_eq!(
-    ///   (UserBounds { l: 1, r: 2 }).try_into_range(5),
-    ///   Ok(Range { start: 0, end: 2}) // 2, not 1, because it's exclusive
+    ///   (UserBounds { l: Side::Some(1), r: Side::Some(2) }).try_into_range(5).unwrap(),
+    ///   Range { start: 0, end: 2} // 2, not 1, because it's exclusive
     /// );
     ///
     /// assert_eq!(
-    ///   (UserBounds { l: 1, r: Side::Continue }).try_into_range(5),
-    ///   Ok(Range { start: 0, end: 5})
+    ///   (UserBounds { l: Side::Some(1), r: Side::Continue }).try_into_range(5).unwrap(),
+    ///   Range { start: 0, end: 5}
     /// );
     /// ```
     pub fn try_into_range(&self, parts_length: usize) -> Result<Range<usize>> {

--- a/src/bounds.rs
+++ b/src/bounds.rs
@@ -114,6 +114,9 @@ impl FromStr for UserBoundsList {
 }
 
 impl UserBoundsList {
+    /// Detect whether the list can be sorted.
+    /// It can be sorted only if every bound
+    /// has the same sign (all positive or all negative).
     fn is_sortable(&self) -> bool {
         let mut has_positive_idx = false;
         let mut has_negative_idx = false;
@@ -176,6 +179,10 @@ impl UserBoundsList {
         })
     }
 
+    /// Check if the bounds in the list match the following conditions:
+    /// - they are in ascending order
+    /// - they use solely positive indices
+    /// - they don't overlap (but they can be adjacent, e.g. 1:2,2,3)
     pub fn is_forward_only(&self) -> bool {
         self.is_sortable() && self.is_sorted() && !self.has_negative_indices()
     }

--- a/src/cut_bytes.rs
+++ b/src/cut_bytes.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use std::io::{Read, Write};
 
-use crate::bounds::{bounds_to_std_range, BoundOrFiller};
+use crate::bounds::BoundOrFiller;
 use crate::options::Opt;
 use crate::read_utils::read_bytes_to_end;
 
@@ -13,7 +13,7 @@ fn cut_bytes<W: Write>(data: &[u8], opt: &Opt, stdout: &mut W) -> Result<()> {
     opt.bounds.0.iter().try_for_each(|bof| -> Result<()> {
         let output = match bof {
             BoundOrFiller::Bound(b) => {
-                let r = bounds_to_std_range(data.len(), b)?;
+                let r = b.try_into_range(data.len())?;
                 &data[r.start..r.end]
             }
             BoundOrFiller::Filler(f) => f.as_bytes(),

--- a/src/cut_lines.rs
+++ b/src/cut_lines.rs
@@ -26,15 +26,15 @@ fn cut_lines_forward_only<A: BufRead, B: Write>(
         // Print the matching fields. Fields are ordered but can still be
         // duplicated, e.g. 1-2,2,3 , so we may have to print the same
         // line multiple times
-        while bounds_idx < opt.bounds.0.len() {
-            let bof = opt.bounds.0.get(bounds_idx).unwrap();
+        while bounds_idx < opt.bounds.len() {
+            let bof = opt.bounds.get(bounds_idx).unwrap();
 
             let b = match bof {
                 BoundOrFiller::Filler(f) => {
                     stdout.write_all(f.as_bytes())?;
                     bounds_idx += 1;
 
-                    if opt.join && bounds_idx != opt.bounds.0.len() {
+                    if opt.join && bounds_idx != opt.bounds.len() {
                         stdout.write_all(&[opt.eol as u8])?;
                     }
 
@@ -57,7 +57,7 @@ fn cut_lines_forward_only<A: BufRead, B: Write>(
                     add_newline_next = false;
 
                     // if opt.join and it was not the last matching bound
-                    if opt.join && bounds_idx != opt.bounds.0.len() {
+                    if opt.join && bounds_idx != opt.bounds.len() {
                         stdout.write_all(&[opt.eol as u8])?;
                     }
 
@@ -68,14 +68,14 @@ fn cut_lines_forward_only<A: BufRead, B: Write>(
             break; // nothing matched, let's go to the next line
         }
 
-        if bounds_idx == opt.bounds.0.len() {
+        if bounds_idx == opt.bounds.len() {
             // no need to read the rest, we don't have other bounds to test
             break;
         }
     }
 
     // Output is finished. Did we output every bound?
-    if let Some(BoundOrFiller::Bound(b)) = opt.bounds.0.get(bounds_idx) {
+    if let Some(BoundOrFiller::Bound(b)) = opt.bounds.get(bounds_idx) {
         if b.r != Side::Continue {
             // not good, we still have bounds to print but the input is exhausted
             bail!("Out of bounds: {}", b);

--- a/src/cut_str.rs
+++ b/src/cut_str.rs
@@ -278,7 +278,9 @@ pub fn cut_str<W: Write>(
         fields.drain(..1);
     }
 
-    if opt.only_delimited && fields.len() == 1 {
+    let num_fields = fields.len();
+
+    if opt.only_delimited && num_fields == 1 {
         // If there's only 1 field it means that there were no delimiters
         // and when used alogside `only_delimited` we must skip the line
         return Ok(());
@@ -310,12 +312,12 @@ pub fn cut_str<W: Write>(
             )
         }) {
             // Yep, there at least a range bound. Let's do it
-            _bounds = bounds.unpack(fields.len());
+            _bounds = bounds.unpack(num_fields);
             bounds = &_bounds;
         }
     }
 
-    match fields.len() {
+    match num_fields {
         1 if bounds.0.len() == 1 => {
             write_maybe_as_json!(stdout, line, opt.json);
         }
@@ -333,10 +335,10 @@ pub fn cut_str<W: Write>(
                         BoundOrFiller::Bound(b) => b,
                     };
 
-                    let mut r_array = vec![b.try_into_range(fields.len())?];
+                    let mut r_array = vec![b.try_into_range(num_fields)?];
 
                     if opt.complement {
-                        r_array = complement_std_range(fields.len(), &r_array[0]);
+                        r_array = complement_std_range(num_fields, &r_array[0]);
                     }
 
                     if opt.json {

--- a/src/cut_str.rs
+++ b/src/cut_str.rs
@@ -25,13 +25,19 @@ fn complement_std_range(parts_length: usize, r: &Range<usize>) -> Vec<Range<usiz
     }
 }
 
-// Split a string into parts and build a vector of ranges that match those parts.
-//
-// `buffer` - vector that will be filled with ranges
-// `line` - the string to split
-// `delimiter` - what to search to split the string
-// `greedy` - whether to consider consecutive delimiters as one or not
-fn build_ranges_vec(buffer: &mut Vec<Range<usize>>, line: &str, delimiter: &str, greedy: bool) {
+/// Split a string into parts and fill a buffer with ranges
+/// that match those parts.
+///
+/// - `buffer` - vector that will be filled with ranges
+/// - `line` - the string to split
+/// - `delimiter` - what to search to split the string
+/// - `greedy` - whether to consider consecutive delimiters as one or not
+fn fill_with_fields_locations(
+    buffer: &mut Vec<Range<usize>>,
+    line: &str,
+    delimiter: &str,
+    greedy: bool,
+) {
     buffer.clear();
 
     if line.is_empty() {
@@ -267,7 +273,7 @@ pub fn cut_str<W: Write>(
             },
         );
     } else {
-        build_ranges_vec(fields, line, delimiter, opt.greedy_delimiter);
+        fill_with_fields_locations(fields, line, delimiter, opt.greedy_delimiter);
     }
 
     if opt.bounds_type == BoundsType::Characters && fields.len() > 2 {
@@ -474,29 +480,29 @@ mod tests {
         // non greedy
 
         v_range.clear();
-        build_ranges_vec(&mut v_range, "", "-", false);
+        fill_with_fields_locations(&mut v_range, "", "-", false);
         assert_eq!(v_range, vec![] as Vec<Range<usize>>);
 
         v_range.clear();
-        build_ranges_vec(&mut v_range, "a", "-", false);
+        fill_with_fields_locations(&mut v_range, "a", "-", false);
         assert_eq!(v_range, vec![Range { start: 0, end: 1 }]);
 
         v_range.clear();
-        build_ranges_vec(&mut v_range, "-", "-", true);
+        fill_with_fields_locations(&mut v_range, "-", "-", true);
         assert_eq!(
             v_range,
             vec![Range { start: 0, end: 0 }, Range { start: 1, end: 1 }]
         );
 
         v_range.clear();
-        build_ranges_vec(&mut v_range, "a-b", "-", false);
+        fill_with_fields_locations(&mut v_range, "a-b", "-", false);
         assert_eq!(
             v_range,
             vec![Range { start: 0, end: 1 }, Range { start: 2, end: 3 }]
         );
 
         v_range.clear();
-        build_ranges_vec(&mut v_range, "-a-", "-", false);
+        fill_with_fields_locations(&mut v_range, "-a-", "-", false);
         assert_eq!(
             v_range,
             vec![
@@ -507,7 +513,7 @@ mod tests {
         );
 
         v_range.clear();
-        build_ranges_vec(&mut v_range, "a--", "-", false);
+        fill_with_fields_locations(&mut v_range, "a--", "-", false);
         assert_eq!(
             v_range,
             vec![
@@ -520,22 +526,22 @@ mod tests {
         // greedy
 
         v_range.clear();
-        build_ranges_vec(&mut v_range, "", "-", true);
+        fill_with_fields_locations(&mut v_range, "", "-", true);
         assert_eq!(v_range, empty_vec);
 
         v_range.clear();
-        build_ranges_vec(&mut v_range, "a", "-", true);
+        fill_with_fields_locations(&mut v_range, "a", "-", true);
         assert_eq!(v_range, vec![Range { start: 0, end: 1 }]);
 
         v_range.clear();
-        build_ranges_vec(&mut v_range, "-", "-", true);
+        fill_with_fields_locations(&mut v_range, "-", "-", true);
         assert_eq!(
             v_range,
             vec![Range { start: 0, end: 0 }, Range { start: 1, end: 1 }]
         );
 
         v_range.clear();
-        build_ranges_vec(&mut v_range, "-a--b", "-", true);
+        fill_with_fields_locations(&mut v_range, "-a--b", "-", true);
         assert_eq!(
             v_range,
             vec![
@@ -546,7 +552,7 @@ mod tests {
         );
 
         v_range.clear();
-        build_ranges_vec(&mut v_range, "-a--", "-", true);
+        fill_with_fields_locations(&mut v_range, "-a--", "-", true);
         assert_eq!(
             v_range,
             vec![

--- a/src/cut_str.rs
+++ b/src/cut_str.rs
@@ -584,24 +584,38 @@ mod tests {
     #[test]
     fn cut_str_echo_non_delimited_strings() {
         let opt = make_fields_opt();
-        let (mut output, mut buffer1, mut buffer2) = make_cut_str_buffers();
         let eol = &[EOL::Newline as u8];
 
         let line = "foo";
 
+        // non-empty line missing the delimiter
+        let (mut output, mut buffer1, mut buffer2) = make_cut_str_buffers();
         cut_str(line, &opt, &mut output, &mut buffer1, &mut buffer2, eol).unwrap();
         assert_eq!(output, b"foo\n".as_slice());
+
+        // empty line
+        let line = "";
+        let (mut output, mut buffer1, mut buffer2) = make_cut_str_buffers();
+        cut_str(line, &opt, &mut output, &mut buffer1, &mut buffer2, eol).unwrap();
+        assert_eq!(output, b"\n".as_slice());
     }
 
     #[test]
     fn cut_str_skip_non_delimited_strings_when_requested() {
         let mut opt = make_fields_opt();
-        let (mut output, mut buffer1, mut buffer2) = make_cut_str_buffers();
         let eol = &[EOL::Newline as u8];
 
         opt.only_delimited = true;
-        let line = "foo";
 
+        // non-empty line missing the delimiter
+        let line = "foo";
+        let (mut output, mut buffer1, mut buffer2) = make_cut_str_buffers();
+        cut_str(line, &opt, &mut output, &mut buffer1, &mut buffer2, eol).unwrap();
+        assert_eq!(output, b"".as_slice());
+
+        // empty line
+        let line = "";
+        let (mut output, mut buffer1, mut buffer2) = make_cut_str_buffers();
         cut_str(line, &opt, &mut output, &mut buffer1, &mut buffer2, eol).unwrap();
         assert_eq!(output, b"".as_slice());
     }

--- a/src/cut_str.rs
+++ b/src/cut_str.rs
@@ -308,7 +308,7 @@ pub fn cut_str<W: Write>(
         // rare usage).
 
         // Start by checking if we actually need to rewrite the bounds
-        if bounds.0.iter().any(|b| {
+        if bounds.iter().any(|b| {
             matches!(
                 b,
                 BoundOrFiller::Bound(UserBounds {
@@ -324,12 +324,11 @@ pub fn cut_str<W: Write>(
     }
 
     match num_fields {
-        1 if bounds.0.len() == 1 => {
+        1 if bounds.len() == 1 => {
             write_maybe_as_json!(stdout, line, opt.json);
         }
         _ => {
             bounds
-                .0
                 .iter()
                 .enumerate()
                 .try_for_each(|(i, bof)| -> Result<()> {
@@ -369,7 +368,7 @@ pub fn cut_str<W: Write>(
                         let field_to_print = maybe_replace_delimiter(output, opt);
                         write_maybe_as_json!(stdout, field_to_print, opt.json);
 
-                        if opt.join && !(i == bounds.0.len() - 1 && idx_r == n_ranges - 1) {
+                        if opt.join && !(i == bounds.len() - 1 && idx_r == n_ranges - 1) {
                             stdout.write_all(
                                 opt.replace_delimiter
                                     .as_ref()

--- a/src/fast_lane.rs
+++ b/src/fast_lane.rs
@@ -87,7 +87,12 @@ fn output_parts<W: Write>(
     opt: &FastOpt,
 ) -> Result<()> {
     let idx_start = fields[r.start].start;
-    let idx_end = fields[r.end - 1].end;
+    let idx_end = fields[if r.end == usize::MAX {
+        fields.len()
+    } else {
+        r.end
+    } - 1]
+        .end;
     let output = &line[idx_start..idx_end];
 
     // let field_to_print = maybe_replace_delimiter(output, opt);

--- a/src/fast_lane.rs
+++ b/src/fast_lane.rs
@@ -160,32 +160,6 @@ impl TryFrom<&Opt> for FastOpt {
     }
 }
 
-impl From<&UserBounds> for Range<usize> {
-    fn from(value: &UserBounds) -> Self {
-        // XXX this will explode in our face at the first negative value
-        // XXX we should have a try into and more checks in place
-        // (also, values must be sequential, but that should be covered by UserBounds
-        // ... if we will still pass by it)
-
-        let (l, r): (usize, usize) = match (value.l, value.r) {
-            // (Side::Some(l), Side::Some(r)) => (l as usize, (r - l) as usize),
-            // (Side::Some(l), Side::Continue) => (l as usize, usize::MAX - (l as usize)),
-            (Side::Some(l), Side::Some(r)) => ((l - 1) as usize, r as usize),
-            (Side::Some(l), Side::Continue) => ((l - 1) as usize, usize::MAX),
-            (Side::Continue, Side::Some(r)) => (0, r as usize),
-            (Side::Continue, Side::Continue) => (0, usize::MAX),
-        };
-
-        // FastRange {
-        //     l,
-        //     r_sub_l: r - l,
-        //     buff_start: 0,
-        //     buff_end: 0,
-        // }
-        Range { start: l, end: r }
-    }
-}
-
 #[derive(Debug)]
 struct ForwardBounds {
     pub list: UserBoundsList,

--- a/src/fast_lane.rs
+++ b/src/fast_lane.rs
@@ -1,0 +1,229 @@
+use crate::bounds::{BoundOrFiller, BoundsType, Side, UserBounds, UserBoundsList};
+use crate::options::{Opt, EOL};
+use anyhow::Result;
+use std::convert::TryFrom;
+use std::io::{self, BufRead};
+use std::{io::Write, ops::Range};
+
+use bstr::io::BufReadExt;
+
+fn cut_str_fast_line<W: Write>(buffer: &[u8], opt: &FastOpt, stdout: &mut W) -> Result<()> {
+    if buffer.is_empty() {
+        return Ok(());
+    }
+
+    let bounds = &opt.bounds;
+    assert!(!bounds.0.is_empty());
+    // if we're here there must be at least one bound to check
+    let last_interesting_field = bounds.0.last().unwrap().end;
+
+    let mut prev_field_start = 0;
+
+    let mut fields: Vec<Range<usize>> = Vec::new();
+
+    let mut curr_field = 0;
+
+    fields.clear();
+
+    for i in memchr::memchr_iter(opt.delimiter, buffer) {
+        curr_field += 1;
+
+        let (start, end) = (prev_field_start, i); // end exclusive
+        prev_field_start = i + 1;
+
+        fields.push(Range { start, end });
+
+        if curr_field == last_interesting_field {
+            // we have no use for this field or any of the following ones
+            break;
+        }
+    }
+
+    if curr_field == 0 && opt.only_delimited {
+        // The delimiter was not found
+        return Ok(());
+    }
+
+    if curr_field != last_interesting_field {
+        fields.push(Range {
+            start: prev_field_start,
+            end: buffer.len(),
+        });
+    }
+
+    let num_fields = fields.len();
+
+    match num_fields {
+        1 if bounds.0.len() == 1 => {
+            stdout.write_all(buffer)?;
+        }
+        _ => {
+            bounds
+                .0
+                .iter()
+                .enumerate()
+                .try_for_each(|(bounds_idx, b)| -> Result<()> {
+                    // let b = match bof {
+                    //     BoundOrFiller::Filler(f) => {
+                    //         stdout.write_all(f.as_bytes())?;
+                    //         return Ok(());
+                    //     }
+                    //     BoundOrFiller::Bound(b) => b,
+                    // };
+
+                    //let mut r_array = vec![b.try_into_range(num_fields)?];
+
+                    let is_last = bounds_idx == bounds.0.len() - 1;
+
+                    output_parts(buffer, b, &fields, stdout, is_last, opt)
+                })?;
+        }
+    }
+
+    stdout.write_all(&[b'\n'])?;
+
+    Ok(())
+}
+
+#[inline]
+fn output_parts<W: Write>(
+    line: &[u8],
+    // which parts to print
+    r: &Range<usize>,
+    // where to find the parts inside `line`
+    fields: &[Range<usize>],
+    stdout: &mut W,
+    is_last: bool,
+    opt: &FastOpt,
+) -> Result<()> {
+    // dbg!(&line.to_str_lossy(), &r, &fields, is_last);
+
+    let idx_start = fields[r.start].start;
+    let idx_end = fields[r.end - 1].end;
+    let output = &line[idx_start..idx_end];
+
+    // let field_to_print = maybe_replace_delimiter(output, opt);
+    let field_to_print = output;
+    stdout.write_all(field_to_print)?;
+
+    if opt.join && !(is_last) {
+        // stdout.write_all(
+        //     opt.replace_delimiter
+        //         .as_ref()
+        //         .unwrap_or(&opt.delimiter)
+        //         .as_bytes(),
+        // )?;
+        stdout.write_all(&[opt.delimiter])?;
+    }
+
+    Ok(())
+}
+
+pub struct FastOpt {
+    delimiter: u8,
+    join: bool,
+    eol: u8,
+    bounds: ForwardBounds,
+    only_delimited: bool,
+}
+
+impl TryFrom<&Opt> for FastOpt {
+    type Error = &'static str;
+
+    fn try_from(value: &Opt) -> Result<Self, Self::Error> {
+        if !value.delimiter.as_bytes().len() == 1 {
+            return Err("Delimiter must be 1 byte wide for FastOpt");
+        }
+
+        if value.complement
+            || value.greedy_delimiter
+            || value.compress_delimiter
+            || value.json
+            || value.bounds_type != BoundsType::Fields
+            || value.replace_delimiter.is_some()
+            || value.trim.is_some()
+            || value.regex_bag.is_some()
+            || matches!(value.eol, EOL::Zero)
+        {
+            return Err(
+                "FastOpt supports solely forward fields, join and single-character delimiters",
+            );
+        }
+
+        if let Ok(forward_bounds) = ForwardBounds::try_from(&value.bounds) {
+            Ok(FastOpt {
+                delimiter: value.delimiter.as_bytes().first().unwrap().to_owned(),
+                join: value.join,
+                eol: b'\n',
+                bounds: forward_bounds,
+                only_delimited: value.only_delimited,
+            })
+        } else {
+            Err("Bounds cannot be converted to ForwardBounds")
+        }
+    }
+}
+
+impl From<&UserBounds> for Range<usize> {
+    fn from(value: &UserBounds) -> Self {
+        // XXX this will explode in our face at the first negative value
+        // XXX we should have a try into and more checks in place
+        // (also, values must be sequential, but that should be covered by UserBounds
+        // ... if we will still pass by it)
+
+        let (l, r): (usize, usize) = match (value.l, value.r) {
+            // (Side::Some(l), Side::Some(r)) => (l as usize, (r - l) as usize),
+            // (Side::Some(l), Side::Continue) => (l as usize, usize::MAX - (l as usize)),
+            (Side::Some(l), Side::Some(r)) => ((l - 1) as usize, r as usize),
+            (Side::Some(l), Side::Continue) => ((l - 1) as usize, usize::MAX),
+            (Side::Continue, Side::Some(r)) => (0, r as usize),
+            (Side::Continue, Side::Continue) => (0, usize::MAX),
+        };
+
+        // FastRange {
+        //     l,
+        //     r_sub_l: r - l,
+        //     buff_start: 0,
+        //     buff_end: 0,
+        // }
+        Range { start: l, end: r }
+    }
+}
+
+#[derive(Debug)]
+pub struct ForwardBounds(Vec<Range<usize>>);
+
+impl TryFrom<&UserBoundsList> for ForwardBounds {
+    type Error = &'static str;
+
+    fn try_from(value: &UserBoundsList) -> Result<Self, Self::Error> {
+        if value.is_forward_only() {
+            let mut v: Vec<Range<usize>> = Vec::with_capacity(value.0.len());
+            for maybe_bounds in value.0.iter() {
+                // XXX for now let's drop the fillers
+                // XXX TODO
+
+                if let BoundOrFiller::Bound(bounds) = maybe_bounds {
+                    v.push(bounds.into());
+                }
+            }
+            Ok(ForwardBounds(v))
+        } else {
+            Err("The provided UserBoundsList is not forward only")
+        }
+    }
+}
+
+pub fn read_and_cut_text_as_bytes<R: BufRead, W: Write>(
+    stdin: &mut R,
+    stdout: &mut W,
+    opt: &FastOpt,
+) -> Result<()> {
+    stdin.for_byte_line(|line| {
+        cut_str_fast_line(line, opt, stdout)
+            .map_err(|x| io::Error::new(io::ErrorKind::Other, x.to_string()))
+            .and(Ok(true))
+    })?;
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod bounds;
 pub mod cut_bytes;
 pub mod cut_lines;
 pub mod cut_str;
+pub mod fast_lane;
 mod json;
 pub mod options;
 mod read_utils;

--- a/src/options.rs
+++ b/src/options.rs
@@ -19,6 +19,15 @@ pub enum EOL {
     Newline = 10,
 }
 
+impl From<EOL> for u8 {
+    fn from(value: EOL) -> Self {
+        match value {
+            EOL::Zero => b'\0',
+            EOL::Newline => b'\n',
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct Opt {
     pub delimiter: String,


### PR DESCRIPTION
Add a simpler, faster parser to use when stars align.
It's still line-based (so we have to read once the line before reading it again to search for fields), but it's much faster, due to a combination of using responsibly `&[u8]` instead of `&str`, faster line reader  (which maybe we will use also for regular `cut_str`), and one-byte delimiter, which allows us to use `memchr`  and its SIMD optimizations.

It can likely be used for cut_bytes too, but that's for another PR.