### PR TITLE
Add a new parser that does not buffer lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,20 +7,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 - perf: much faster (from 2x up to 3x) implementation:
-  * there is now a fast lane used when conditions apply (more or less
+  - there is now a fast lane used when conditions apply (more or less
     it triggers when you cut fields on 1-byte characters)
-  * fields cut is now done on bytes, not strings (as long as your
+  - fields cut is now done on bytes, not strings (as long as your
     delimiter is proper utf-8 you'll be fine)
 - feat: display short help when run without arguments
 - feat: add the ability to display fallback output when a field is out of bound
   (you can set it per-field using `-f <range>=somefallback` or by providing
   a generic fallback using `--fallback-oob somefallback`)
 - feat: it is now possible to type \t while formatting fields and
-  output a TAB (as we similary do for \n) e.g. `-f '{1}\t{2}'`
+  output a TAB (as we already do for \n) e.g. `-f '{1}\t{2}'`
+- feat: new argument --fixed-memory (-M) to cut lines in chunks of
+  a fixed size (in kilobytes), to allow cutting arbitrary long lines
 - feat: --characters now depends on the (default) regex feature
 - feat: help and short help are colored, as long as output is a tty and
   unless env var TERM=dumb or NO_COLOR (any value) is set
 - refactor: --json internally uses serde_json, faster and more precise
+- chore: improved test coverage
 
 ## [1.2.0] - 2024-01-01
 
@@ -114,12 +117,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [0.4.0] - 2020-05-31
 
 ### Changed
+
 - Build binaries for multiple operative systems
 - Fixed typos in the documentation
 
 ## [0.3.0] - 2020-05-31
 
 ### Changed
+
 - More examples
 - New releases system
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # tuc (when cut doesn't cut it)
+
 [![version](https://img.shields.io/crates/v/tuc.svg)](https://crates.io/crates/tuc)
 ![ci](https://github.com/riquito/tuc/actions/workflows/ci.yml/badge.svg)
 [![license](https://img.shields.io/crates/l/tuc.svg)](https://crates.io/crates/tuc)
 
-You want to `cut` on more than just a character, perhaps using negative indexes 
+You want to `cut` on more than just a character, perhaps using negative indexes
 or format the selected fields as you want...
 Maybe you want to cut on lines (ever needed to drop or keep first and last line?)...
 That's where `tuc` can help.
@@ -90,6 +91,10 @@ OPTIONS:
                                   cannot be found (oob stands for out of bound).
                                   It's overridden by any fallback assigned to a
                                   specific field (see -f for help)
+    -M, --fixed-memory <size>     Read the input in chunks of <size> kilobytes.
+                                  This allows to read lines arbitrarily large.
+                                  Works only with single-byte delimiters,
+                                  fields in ascending order, -z, -j, -r
 
 Options precedence:
     --trim and --compress-delimiter are applied before --fields or similar
@@ -102,6 +107,10 @@ Memory consumption:
     the whole input in memory (it also happens when -p or -m are being used)
 
     --bytes allocate the whole input in memory
+
+    --fixed-memory will read the input in chunks of <size> kilobytes. This
+    allows to read lines arbitrarily large. Works only with single-byte
+    delimiters, fields in ascending order, -z, -j, -r
 
 Colors:
     Help is displayed using colors. Colors will be suppressed in the
@@ -228,12 +237,14 @@ Heartfelt thanks to package maintainers: you make it easy to access open source 
 [![Packaging status](https://repology.org/badge/vertical-allrepos/tuc-cut.svg)](https://repology.org/project/tuc-cut/versions)
 
 - [ArchLinux](https://aur.archlinux.org/packages/tuc):
+
   ```sh
   yay -S tuc # compile from source
   yay -S tuc-bin # install pre-built binaries tuc and tuc-regex
   ```
 
 - [Brew](https://formulae.brew.sh/formula/tuc):
+
   ```sh
   brew install tuc
   ```

--- a/doc/tuc.1
+++ b/doc/tuc.1
@@ -31,31 +31,31 @@ parts.
 The data is read from standard input.
 .SH FLAGS
 .TP
-.B \-g, --greedy-delimiter
+-g, --greedy-delimiter
 Match consecutive delimiters as if it was one
 .TP
-.B \-p, --compress-delimiter
+-p, --compress-delimiter
 Print only the first delimiter of a sequence
 .TP
-.B \-s, --only-delimited
+-s, --only-delimited
 Print only lines containing the delimiter
 .TP
-.B \-V, --version
+-V, --version
 Print version information
 .TP
-.B \-z, --zero-terminated
+-z, --zero-terminated
 Line delimiter is NUL (\[rs]0), not LF (\[rs]n)
 .TP
-.B \-h, --help
+-h, --help
 Print this help and exit
 .TP
-.B \-m, --complement
+-m, --complement
 Invert fields (e.g.\ \[aq]2\[aq] becomes \[aq]1,3:\[aq])
 .TP
-.B \-j, --(no-)join
+-j, --(no-)join
 Print selected parts with delimiter in between
 .TP
-.B --json
+--json
 Print fields as a JSON array of strings
 .SH OPTIONS
 .PP
@@ -199,6 +199,24 @@ To merge lines, use --no-join
 .P
 .PD
 \ \ \ \ \ \ \ specific field (see -f for help)
+.PP
+\f[B]-M\f[R], \f[B]--fixed-memory\f[R] [size]
+.PD 0
+.P
+.PD
+\ \ \ \ \ \ \ Read the input in chunks of kilobytes.
+.PD 0
+.P
+.PD
+\ \ \ \ \ \ \ This allows to read lines arbitrarily large.
+.PD 0
+.P
+.PD
+\ \ \ \ \ \ \ Works only with single-byte delimiters,
+.PD 0
+.P
+.PD
+\ \ \ \ \ \ \ fields in ascending order, -z, -j, -r
 .SH OPTIONS PRECEDENCE
 .PP
 --trim and --compress-delimiter are applied before --fields or similar
@@ -218,6 +236,18 @@ ordered and non-negative (e.g.\ -l 1,3:4,4,7), otherwise it allocates
 the whole input in memory (it also happens when -p or -m are being used)
 .PP
 --bytes allocate the whole input in memory
+.PP
+--fixed-memory will read the input in chunks of kilobytes.
+This
+.PD 0
+.P
+.PD
+allows to read lines arbitrarily large.
+Works only with single-byte
+.PD 0
+.P
+.PD
+delimiters, fields in ascending order, -z, -j, -r
 .SH COLORS
 .PP
 Help is displayed using colors.

--- a/doc/tuc.1.md
+++ b/doc/tuc.1.md
@@ -108,6 +108,12 @@ OPTIONS
 |        It's overridden by any fallback assigned to a
 |        specific field (see -f for help)
 
+| **-M**, **\--fixed-memory** [size]
+|        Read the input in chunks of <size> kilobytes.
+|        This allows to read lines arbitrarily large.
+|        Works only with single-byte delimiters,
+|        fields in ascending order, -z, -j, -r
+
 OPTIONS PRECEDENCE
 ==================
 
@@ -123,6 +129,10 @@ MEMORY CONSUMPTION
 | the whole input in memory (it also happens when -p or -m are being used)
 
 \--bytes allocate the whole input in memory
+
+| \--fixed-memory will read the input in chunks of <size> kilobytes. This
+| allows to read lines arbitrarily large. Works only with single-byte
+| delimiters, fields in ascending order, -z, -j, -r
 
 COLORS
 ======

--- a/src/bin/tuc.rs
+++ b/src/bin/tuc.rs
@@ -9,6 +9,7 @@ use tuc::cut_lines::read_and_cut_lines;
 use tuc::cut_str::read_and_cut_str;
 use tuc::help::{get_help, get_short_help};
 use tuc::options::{Opt, EOL};
+use tuc::stream::{read_and_cut_bytes_stream, StreamOpt};
 
 #[cfg(feature = "fast-lane")]
 use tuc::fast_lane::{read_and_cut_text_as_bytes, FastOpt};
@@ -251,6 +252,8 @@ fn main() -> Result<()> {
         read_and_cut_bytes(&mut stdin, &mut stdout, &opt)?;
     } else if opt.bounds_type == BoundsType::Lines {
         read_and_cut_lines(&mut stdin, &mut stdout, &opt)?;
+    } else if let Ok(stream_opt) = StreamOpt::try_from(&opt) {
+        read_and_cut_bytes_stream(&mut stdin, &mut stdout, &stream_opt)?;
     } else if let Ok(fast_opt) = FastOpt::try_from(&opt) {
         read_and_cut_text_as_bytes(&mut stdin, &mut stdout, &fast_opt)?;
     } else {

--- a/src/bounds/prove.rs
+++ b/src/bounds/prove.rs
@@ -1,0 +1,106 @@
+use anyhow::{bail, Result};
+use std::cmp::Ordering;
+use std::fmt;
+use std::str::FromStr;
+
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
+pub enum Side<T> {
+    Some(T),
+    Continue,
+}
+
+#[derive(Debug, PartialEq, PartialOrd)]
+pub struct Rel(i32);
+#[derive(Debug, PartialEq, PartialOrd)]
+pub struct Abs(usize);
+
+trait Num {
+    type T;
+    fn zero() -> Self::T;
+    fn value(&self) -> Self::T;
+}
+
+impl Num for Rel {
+    type T = i32;
+    fn zero() -> T {
+        return 0;
+    }
+    fn value(&self) -> T {
+        return self.0;
+    }
+}
+
+#[derive(Debug, PartialOrd, PartialEq)]
+pub struct Bounds<T> {
+    left: Side<T>,
+    right: Side<T>,
+}
+
+pub type RelBounds = Bounds<Rel>;
+pub type AbsBounds = Bounds<Abs>;
+
+pub enum BoundsOrFiller<T> {
+    Bounds(Bounds<T>),
+    Filler,
+}
+
+pub struct BoundsList<T> {
+    pub list: Vec<BoundsOrFiller<T>>,
+}
+
+fn bigger_than(lhs: &Bounds<Rel>, rhs: &Bounds<Rel>) -> bool {
+    lhs.left.partial_cmp(&rhs.left).is_some()
+}
+
+fn foobar(lhs: &Bounds<Rel>) -> bool {
+    match &lhs.left {
+        Side::Some(Rel(x)) => {
+            *x > 0;
+        }
+        Side::Continue => {}
+    };
+
+    true
+}
+
+fn foobar222<T: Num>(lhs: &Bounds<T>) -> bool {
+    match &lhs.left {
+        Side::Some(x) => {
+            x.value() > T::zero();
+        }
+        Side::Continue => {}
+    };
+
+    true
+}
+
+fn main() {
+    let lol = BoundsList {
+        list: vec![
+            BoundsOrFiller::Bounds(Bounds {
+                left: Side::Some(Rel(1)),
+                right: Side::Some(Rel(5)),
+            }),
+            BoundsOrFiller::Filler,
+            BoundsOrFiller::Bounds(Bounds {
+                left: Side::Some(Rel(1)),
+                right: Side::Some(Rel(5)),
+            }),
+        ],
+    };
+
+    let prove: Vec<&Bounds<Rel>> = lol
+        .list
+        .iter()
+        .filter_map(|x| match (x) {
+            BoundsOrFiller::Bounds(bounds) => {
+                println!("Bounds: {:?}", bounds);
+                Some(bounds)
+            }
+            BoundsOrFiller::Filler => {
+                println!("Filler");
+                None
+            }
+        })
+        .collect();
+}

--- a/src/bounds/prove2.rs
+++ b/src/bounds/prove2.rs
@@ -1,0 +1,62 @@
+use anyhow::{bail, Result};
+use std::cmp::Ordering;
+use std::fmt;
+use std::str::FromStr;
+
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
+pub enum Side<T> {
+    Some(T),
+    Continue,
+}
+
+trait Num {
+    type T;
+    fn zero() -> Self::T;
+    fn value(&self, max: Self::T) -> Self::T;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
+pub struct Bounds<T> {
+    pub l: Side<T>,
+    pub r: Side<T>,
+}
+
+pub enum BoundsOrFiller<T> {
+    Bounds(Bounds<T>),
+    Filler,
+}
+
+pub struct BoundsList<T> {
+    pub list: Vec<BoundsOrFiller<T>>,
+}
+
+fn main() {
+    let lol = BoundsList {
+        list: vec![
+            BoundsOrFiller::Bounds(Bounds {
+                l: Side::Some(1),
+                r: Side::Some(5),
+            }),
+            BoundsOrFiller::Filler,
+            BoundsOrFiller::Bounds(Bounds {
+                l: Side::Some(1),
+                r: Side::Some(5),
+            }),
+        ],
+    };
+
+    let prove: Vec<&Bounds<i32>> = lol
+        .list
+        .iter()
+        .filter_map(|x| match x {
+            BoundsOrFiller::Bounds(bounds) => {
+                println!("Bounds: {:?}", bounds);
+                Some(bounds)
+            }
+            BoundsOrFiller::Filler => {
+                println!("Filler");
+                None
+            }
+        })
+        .collect();
+}

--- a/src/bounds/prove3.rs
+++ b/src/bounds/prove3.rs
@@ -1,0 +1,75 @@
+use anyhow::{bail, Result};
+use std::cmp::Ordering;
+use std::fmt;
+use std::str::FromStr;
+
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
+struct SideValue(usize, usize);
+
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
+pub enum Side {
+    Some(SideValue),
+    Continue,
+}
+
+impl Side {
+    fn new(v: usize) -> Self {
+        Side::Some(SideValue(v, 0))
+    }
+
+    fn new_with_offset(v: usize, offset: usize) -> Self {
+        Side::Some(SideValue(v, v + offset))
+    }
+}
+
+trait Num {
+    type T;
+    fn zero() -> Self::T;
+    fn value(&self, max: Self::T) -> Self::T;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
+pub struct Bounds {
+    pub l: Side,
+    pub r: Side,
+}
+
+pub enum BoundsOrFiller {
+    Bounds(Bounds),
+    Filler,
+}
+
+pub struct BoundsList {
+    pub list: Vec<BoundsOrFiller>,
+}
+
+fn main() {
+    let lol = BoundsList {
+        list: vec![
+            BoundsOrFiller::Bounds(Bounds {
+                l: Side::new(1),
+                r: Side::new(5),
+            }),
+            BoundsOrFiller::Filler,
+            BoundsOrFiller::Bounds(Bounds {
+                l: Side::new(1),
+                r: Side::new(5),
+            }),
+        ],
+    };
+
+    let prove: Vec<&Bounds> = lol
+        .list
+        .iter()
+        .filter_map(|x| match x {
+            BoundsOrFiller::Bounds(bounds) => {
+                println!("Bounds: {:?}", bounds);
+                Some(bounds)
+            }
+            BoundsOrFiller::Filler => {
+                println!("Filler");
+                None
+            }
+        })
+        .collect();
+}

--- a/src/cut_str.rs
+++ b/src/cut_str.rs
@@ -384,51 +384,44 @@ pub fn cut_str<W: Write>(
         }
     }
 
-    match num_fields {
-        1 if bounds.len() == 1 => {
-            write_maybe_as_json!(stdout, line, opt.json);
+    bounds.iter().try_for_each(|bof| -> Result<()> {
+        let b = match bof {
+            BoundOrFiller::Filler(f) => {
+                stdout.write_all(f.as_bytes())?;
+                return Ok(());
+            }
+            BoundOrFiller::Bound(b) => b,
+        };
+
+        let r = b.try_into_range(num_fields);
+
+        let output = if r.is_ok() {
+            let r = r.unwrap();
+            let idx_start = fields[r.start].start;
+            let idx_end = fields[r.end - 1].end;
+            &line[idx_start..idx_end]
+        } else if b.fallback_oob.is_some() {
+            b.fallback_oob.as_ref().unwrap()
+        } else if let Some(generic_fallback) = &opt.fallback_oob {
+            generic_fallback
+        } else {
+            return Err(r.unwrap_err());
+        };
+
+        let field_to_print = maybe_replace_delimiter(output, opt);
+        write_maybe_as_json!(stdout, field_to_print, opt.json);
+
+        if opt.join && !b.is_last {
+            stdout.write_all(
+                opt.replace_delimiter
+                    .as_ref()
+                    .unwrap_or(&opt.delimiter)
+                    .as_bytes(),
+            )?;
         }
-        _ => {
-            bounds.iter().try_for_each(|bof| -> Result<()> {
-                let b = match bof {
-                    BoundOrFiller::Filler(f) => {
-                        stdout.write_all(f.as_bytes())?;
-                        return Ok(());
-                    }
-                    BoundOrFiller::Bound(b) => b,
-                };
 
-                let r = b.try_into_range(num_fields);
-
-                let output = if r.is_ok() {
-                    let r = r.unwrap();
-                    let idx_start = fields[r.start].start;
-                    let idx_end = fields[r.end - 1].end;
-                    &line[idx_start..idx_end]
-                } else if b.fallback_oob.is_some() {
-                    b.fallback_oob.as_ref().unwrap()
-                } else if let Some(generic_fallback) = &opt.fallback_oob {
-                    generic_fallback
-                } else {
-                    return Err(r.unwrap_err());
-                };
-
-                let field_to_print = maybe_replace_delimiter(output, opt);
-                write_maybe_as_json!(stdout, field_to_print, opt.json);
-
-                if opt.join && !b.is_last {
-                    stdout.write_all(
-                        opt.replace_delimiter
-                            .as_ref()
-                            .unwrap_or(&opt.delimiter)
-                            .as_bytes(),
-                    )?;
-                }
-
-                Ok(())
-            })?;
-        }
-    }
+        Ok(())
+    })?;
 
     if opt.json {
         stdout.write_all(b"]")?;

--- a/src/cut_str.rs
+++ b/src/cut_str.rs
@@ -1232,4 +1232,22 @@ mod tests {
 "#
         );
     }
+
+    #[test]
+    fn test_cut_bytes_stream_cut_simplest_field_with_eol_and_fallbacks() {
+        let mut opt = make_fields_opt();
+        let (mut output, mut buffer1, mut buffer2) = make_cut_str_buffers();
+        let eol = &[EOL::Newline as u8];
+
+        let line = b"a";
+        opt.fallback_oob = Some(b"generic fallback".to_vec());
+        opt.bounds = UserBoundsList::from_str("{1}-fill-{2}-more fill-{3=last fill}").unwrap();
+
+        cut_str(line, &opt, &mut output, &mut buffer1, &mut buffer2, eol).unwrap();
+
+        assert_eq!(
+            &String::from_utf8_lossy(&output),
+            "a-fill-generic fallback-more fill-last fill\n"
+        );
+    }
 }

--- a/src/help.rs
+++ b/src/help.rs
@@ -67,6 +67,10 @@ OPTIONS:
                                   cannot be found (oob stands for out of bound).
                                   It's overridden by any fallback assigned to a
                                   specific field (see -f for help)
+    -M, --fixed-memory <size>     Read the input in chunks of <size> kilobytes.
+                                  This allows to read lines arbitrarily large.
+                                  Works only with single-byte delimiters,
+                                  fields in ascending order, -z, -j, -r
 
 Options precedence:
     --trim and --compress-delimiter are applied before --fields or similar
@@ -79,6 +83,10 @@ Memory consumption:
     the whole input in memory (it also happens when -p or -m are being used)
 
     --bytes allocate the whole input in memory
+
+    --fixed-memory will read the input in chunks of <size> kilobytes. This
+    allows to read lines arbitrarily large. Works only with single-byte
+    delimiters, fields in ascending order, -z, -j, -r
 
 Colors:
     Help is displayed using colors. Colors will be suppressed in the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,3 +7,4 @@ pub mod fast_lane;
 pub mod help;
 pub mod options;
 mod read_utils;
+pub mod stream;

--- a/src/options.rs
+++ b/src/options.rs
@@ -43,6 +43,7 @@ pub struct Opt {
     pub complement: bool,
     pub join: bool,
     pub json: bool,
+    pub fixed_memory: Option<usize>,
     pub fallback_oob: Option<Vec<u8>>,
     #[cfg(feature = "regex")]
     pub regex_bag: Option<RegexBag>,
@@ -66,6 +67,7 @@ impl Default for Opt {
             complement: false,
             join: false,
             json: false,
+            fixed_memory: None,
             fallback_oob: None,
             regex_bag: None,
         }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,0 +1,811 @@
+use crate::bounds::{BoundOrFiller, BoundsType, Side, UserBounds, UserBoundsList, UserBoundsTrait};
+use crate::options::{Opt, EOL};
+use anyhow::bail;
+use anyhow::Result;
+use bstr::ByteSlice;
+use core::panic;
+use std::convert::TryFrom;
+use std::io::BufRead;
+use std::io::Write;
+use std::ops::Deref;
+use std::str::FromStr;
+
+#[derive(Debug)]
+struct ForwardBounds {
+    pub list: UserBoundsList,
+    last_bound_idx: usize,
+}
+
+impl TryFrom<&UserBoundsList> for ForwardBounds {
+    type Error = &'static str;
+
+    fn try_from(value: &UserBoundsList) -> Result<Self, Self::Error> {
+        if value.is_empty() {
+            Err("Cannot create ForwardBounds from an empty UserBoundsList")
+        } else if value.is_forward_only() {
+            let mut prev_bound_idx = Side::Some(0);
+            value.iter().try_for_each(|bof| {
+                if let BoundOrFiller::Bound(b) = bof {
+                    if b.l == prev_bound_idx {
+                        return Err("Bounds are sorted, but can't be repeated");
+                    }
+                    prev_bound_idx = b.l;
+                }
+                Ok(())
+            })?;
+
+            let value: UserBoundsList =
+                value.iter().cloned().collect::<Vec<BoundOrFiller>>().into();
+            let mut maybe_last_bound: Option<usize> = None;
+            value.iter().enumerate().rev().any(|(idx, bof)| {
+                if matches!(bof, BoundOrFiller::Bound(_)) {
+                    maybe_last_bound = Some(idx);
+                    true
+                } else {
+                    false
+                }
+            });
+
+            if let Some(last_bound_idx) = maybe_last_bound {
+                Ok(ForwardBounds {
+                    list: value,
+                    last_bound_idx,
+                })
+            } else {
+                Err("Cannot create ForwardBounds from UserBoundsList without bounds")
+            }
+        } else {
+            Err("The provided UserBoundsList is not forward only")
+        }
+    }
+}
+
+impl FromStr for ForwardBounds {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.trim().is_empty() {
+            bail!("UserBoundsList must contain at least one UserBounds");
+        }
+        let bounds = UserBoundsList::from_str(s)?;
+        ForwardBounds::try_from(&bounds).map_err(|e| anyhow::anyhow!(e))
+    }
+}
+
+impl Deref for ForwardBounds {
+    type Target = UserBoundsList;
+
+    fn deref(&self) -> &Self::Target {
+        &self.list
+    }
+}
+
+impl ForwardBounds {
+    fn get_last_bound(&self) -> &UserBounds {
+        if let Some(BoundOrFiller::Bound(b)) = self.list.get(self.last_bound_idx) {
+            b
+        } else {
+            panic!("Invariant error: last_bound_idx failed to match a bound")
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct StreamOpt {
+    delimiter: u8,
+    replace_delimiter: Option<u8>,
+    join: bool,
+    eol: EOL,
+    fallback_oob: Option<Vec<u8>>,
+    bounds: ForwardBounds,
+    // ## only_delimited: bool, ##
+    // We can't support it, because we read fixed blocks of data.
+    // If we don't find the delimiter in one block and move the next block,
+    // and then we find the delimiter, we can't print the content from the
+    // previous block, it's lost.
+    // The alternative would be to start buffering blocks, but who knows
+    // how much they'd grow: it would be not different from buffering the
+    // whole line, and this mode is about doing the job with fixed memory.
+}
+
+impl TryFrom<&Opt> for StreamOpt {
+    type Error = &'static str;
+
+    fn try_from(value: &Opt) -> Result<Self, Self::Error> {
+        if value.delimiter.as_bytes().len() != 1 {
+            return Err("Delimiter must be 1 byte wide for FastOpt");
+        }
+
+        if value.complement
+            || value.greedy_delimiter
+            || value.compress_delimiter
+            || value.json
+            || value.bounds_type != BoundsType::Fields
+            || (value.replace_delimiter.is_some() && value.replace_delimiter.as_ref().unwrap().len() != 1)
+            || value.trim.is_some()
+            || value.regex_bag.is_some()
+            // only_delimited can't be supported without reading the full line first
+            // to search for delimiters, which can't be done if we read by chunks.
+            || value.only_delimited
+        {
+            return Err(
+                "StreamOpt supports solely forward fields, join and single-character delimiters",
+            );
+        }
+
+        if let Ok(forward_bounds) = ForwardBounds::try_from(&value.bounds) {
+            Ok(StreamOpt {
+                delimiter: value.delimiter.as_bytes().first().unwrap().to_owned(),
+                replace_delimiter: value
+                    .replace_delimiter
+                    .as_ref()
+                    .map(|s| s.as_bytes().first().unwrap().to_owned()),
+                join: value.join,
+                eol: value.eol,
+                bounds: forward_bounds,
+                fallback_oob: value.fallback_oob.clone(),
+            })
+        } else {
+            Err("Bounds cannot be converted to ForwardBounds")
+        }
+    }
+}
+
+pub fn read_and_cut_bytes_stream<R: BufRead, W: Write>(
+    stdin: &mut R,
+    stdout: &mut W,
+    opt: &StreamOpt,
+) -> Result<()> {
+    let last_interesting_field = opt.bounds.get_last_bound().r;
+    cut_bytes_stream(stdin, stdout, opt, last_interesting_field)?;
+    Ok(())
+}
+
+#[inline(always)]
+fn print_field<W: Write>(
+    stdin: &mut W,
+    buffer: &[u8],
+    delim: u8,
+    prepend_delimiter: bool,
+) -> Result<()> {
+    if prepend_delimiter {
+        stdin.write_all(&[delim])?;
+    }
+    stdin.write_all(buffer)?;
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+#[inline(always)]
+fn print_bof<W: Write>(
+    stdout: &mut W,
+    opt: &StreamOpt,
+    bof_idx: usize,
+    curr_field: i32,
+    chunk: &[u8],
+    prev_chunk_idx: usize,
+    chunk_idx: usize,
+    prev_chunk_may_be_truncated: bool,
+) -> Result<usize> {
+    let mut bof_idx = bof_idx;
+
+    if let Some(BoundOrFiller::Filler(f)) = opt.bounds.get(bof_idx) {
+        stdout.write_all(f)?;
+        bof_idx += 1;
+    }
+
+    if let Some(BoundOrFiller::Bound(b)) = opt.bounds.get(bof_idx) {
+        // Bound may not match when, at example, we are waiting to print
+        // field 4 but we are at field 2.
+        if b.matches(curr_field).unwrap() {
+            let prepend_delimiter = !prev_chunk_may_be_truncated
+                && curr_field > 1
+                && (opt.join || (b.l != Side::Some(curr_field)));
+
+            let delimiter = opt.replace_delimiter.unwrap_or(opt.delimiter);
+
+            print_field(
+                stdout,
+                &chunk[prev_chunk_idx..chunk_idx],
+                delimiter,
+                prepend_delimiter,
+            )?;
+
+            if b.r == Side::Some(curr_field) {
+                bof_idx += 1;
+            }
+        }
+    }
+
+    Ok(bof_idx)
+}
+
+// Exhaust bounds and print fillers or fallbacks.
+// This function is meant to be called after every
+// bound has been found and possibly printed, and
+// the rest of the bof (bound or filler) are expected
+// to be either filler or bounds with a fallback.
+fn print_filler_or_fallbacks<W: Write>(
+    stdout: &mut W,
+    bof_idx: usize,
+    opt: &StreamOpt,
+) -> Result<()> {
+    for bof in opt.bounds[bof_idx..].iter() {
+        let b = match bof {
+            BoundOrFiller::Filler(f) => {
+                stdout.write_all(f.as_bytes())?;
+                continue;
+            }
+            BoundOrFiller::Bound(b) => b,
+        };
+
+        if b.r == Side::Continue {
+            break;
+        }
+
+        let output = if b.fallback_oob.is_some() {
+            b.fallback_oob.as_ref().unwrap()
+        } else if let Some(generic_fallback) = &opt.fallback_oob {
+            generic_fallback
+        } else {
+            bail!("Out of bounds: {}", b.l);
+        };
+
+        stdout.write_all(output)?;
+    }
+
+    Ok(())
+}
+
+fn cut_bytes_stream<R: BufRead, W: Write>(
+    stdin: &mut R,
+    stdout: &mut W,
+    opt: &StreamOpt,
+    last_interesting_field: Side,
+) -> Result<()> {
+    let eol: u8 = opt.eol.into();
+    let mut eof = false;
+
+    'new_line: loop {
+        let mut bof_idx = 0;
+        let mut curr_field = 1;
+        let mut prev_chunk_may_be_truncated = false;
+        let mut eol_reached = false;
+        let mut empty_line = true;
+
+        'new_chunk: while !eol_reached && !eof {
+            let chunk = stdin.fill_buf()?;
+
+            if chunk.is_empty() {
+                eof = true;
+                if empty_line {
+                    eol_reached = true;
+                }
+                break 'new_chunk;
+            }
+
+            empty_line = false;
+
+            let mut chunk_part_start_idx = 0;
+            let mut bytes_to_consume = 0;
+
+            // Process chunk looking for delimiters or EOL
+            for chunk_idx in memchr::memchr2_iter(opt.delimiter, eol, chunk) {
+                eol_reached = chunk[chunk_idx] == eol;
+                bytes_to_consume = chunk_idx + 1;
+
+                // Handle field content before delimiter/EOL
+                if bytes_to_consume > 1 {
+                    bof_idx = print_bof(
+                        stdout,
+                        opt,
+                        bof_idx,
+                        curr_field,
+                        chunk,
+                        chunk_part_start_idx,
+                        chunk_idx,
+                        prev_chunk_may_be_truncated,
+                    )?;
+                }
+
+                prev_chunk_may_be_truncated = false;
+                // Update chunk_part_start_idx to point to the next field
+                chunk_part_start_idx = chunk_idx + 1;
+
+                // EOL handling
+                if eol_reached {
+                    print_filler_or_fallbacks(stdout, bof_idx, opt)?;
+                    stdout.write_all(&[opt.eol.into()])?;
+                    break;
+                }
+
+                // If we've found the last field we're interested in
+                if Side::Some(curr_field) == last_interesting_field {
+                    // Print any remaining fillers (no fallbacks, since we're done with the fields)
+                    print_filler_or_fallbacks(stdout, bof_idx, opt)?;
+
+                    // Attempt to skip to EOL (if it's not in this chunk we'll wait for the next chunk)
+                    if let Some(eol_idx) = memchr::memchr(eol, &chunk[bytes_to_consume..]) {
+                        bytes_to_consume = bytes_to_consume + eol_idx + 1;
+                        eol_reached = true;
+                        stdout.write_all(&[opt.eol.into()])?;
+                    }
+
+                    break;
+                }
+
+                curr_field += 1;
+            }
+
+            // Handle remaining data in chunk
+            if !eol_reached {
+                let chunk_has_unused_content = chunk.len() > bytes_to_consume;
+
+                if chunk_has_unused_content {
+                    // Process potential partial field
+                    bof_idx = print_bof(
+                        stdout,
+                        opt,
+                        bof_idx,
+                        curr_field,
+                        chunk,
+                        chunk_part_start_idx,
+                        chunk.len(),
+                        prev_chunk_may_be_truncated,
+                    )?;
+                    prev_chunk_may_be_truncated = true;
+                }
+
+                bytes_to_consume = chunk.len();
+            }
+
+            stdin.consume(bytes_to_consume);
+
+            // let's loop and read the next chunk
+        }
+
+        // Handle EOF at end of line
+        if eof && !eol_reached {
+            print_filler_or_fallbacks(stdout, bof_idx, opt)?;
+            stdout.write_all(&[opt.eol.into()])?;
+            break 'new_line;
+        }
+
+        // If we've reached EOF, exit the outer loop too
+        if eof {
+            break 'new_line;
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+
+    use std::{io::BufReader, str::FromStr};
+
+    use super::*;
+
+    fn make_fields_opt() -> StreamOpt {
+        StreamOpt {
+            delimiter: b'-',
+            replace_delimiter: None,
+            eol: EOL::Newline,
+            join: false,
+            fallback_oob: None,
+            bounds: ForwardBounds::from_str("1").unwrap(),
+        }
+    }
+
+    #[test]
+    fn test_cut_bytes_stream_cut_simplest_field_no_eol() {
+        let mut stdout = Vec::new();
+        let mut stdin = b"a".as_slice();
+        let mut opt = make_fields_opt();
+        opt.bounds = ForwardBounds::from_str("1").unwrap();
+        let last_interesting_field = opt.bounds.get_last_bound().r;
+
+        cut_bytes_stream(&mut stdin, &mut stdout, &opt, last_interesting_field).unwrap();
+
+        assert_eq!(stdout.to_str_lossy(), b"a\n".as_slice().to_str_lossy());
+    }
+
+    #[test]
+    fn test_cut_bytes_stream_cut_simplest_field_with_eol() {
+        let mut stdout = Vec::new();
+        let mut stdin = b"a\n".as_slice();
+        let mut opt = make_fields_opt();
+        opt.bounds = ForwardBounds::from_str("1").unwrap();
+        let last_interesting_field = opt.bounds.get_last_bound().r;
+
+        cut_bytes_stream(&mut stdin, &mut stdout, &opt, last_interesting_field).unwrap();
+
+        assert_eq!(stdout.to_str_lossy(), b"a\n".as_slice().to_str_lossy());
+    }
+
+    #[test]
+    fn test_cut_bytes_stream_cut_simplest_field_with_eol_and_fallbacks() {
+        let mut stdout = Vec::new();
+        let mut stdin = b"a\n".as_slice();
+        let mut opt = make_fields_opt();
+        opt.fallback_oob = Some(b"generic fallback".to_vec());
+        opt.bounds = ForwardBounds::from_str("{1}-fill-{2}-more fill-{3=last fill}").unwrap();
+        let last_interesting_field = opt.bounds.get_last_bound().r;
+
+        cut_bytes_stream(&mut stdin, &mut stdout, &opt, last_interesting_field).unwrap();
+
+        assert_eq!(
+            stdout.to_str_lossy(),
+            b"a-fill-generic fallback-more fill-last fill\n"
+                .as_slice()
+                .to_str_lossy()
+        );
+    }
+
+    #[test]
+    fn test_cut_bytes_stream_cut_simplest_field_with_eol_out_of_bounds() {
+        let mut stdout = Vec::new();
+        let mut stdin = b"a\n".as_slice();
+        let mut opt = make_fields_opt();
+        opt.bounds = ForwardBounds::from_str("2").unwrap();
+        let last_interesting_field = opt.bounds.get_last_bound().r;
+
+        let res = cut_bytes_stream(&mut stdin, &mut stdout, &opt, last_interesting_field);
+        let error = res.unwrap_err();
+        assert_eq!(format!("{}", error), "Out of bounds: 2");
+    }
+
+    #[test]
+    fn test_cut_bytes_stream_cut_simplest_field_with_eof_and_fallbacks() {
+        let mut stdout = Vec::new();
+        let mut stdin = b"a".as_slice();
+        let mut opt = make_fields_opt();
+        opt.fallback_oob = Some(b"generic fallback".to_vec());
+        opt.bounds = ForwardBounds::from_str("{1}-fill-{2}-more fill-{3=last fill}").unwrap();
+        let last_interesting_field = opt.bounds.get_last_bound().r;
+
+        cut_bytes_stream(&mut stdin, &mut stdout, &opt, last_interesting_field).unwrap();
+
+        assert_eq!(
+            stdout.to_str_lossy(),
+            b"a-fill-generic fallback-more fill-last fill\n"
+                .as_slice()
+                .to_str_lossy()
+        );
+    }
+
+    #[test]
+    fn test_cut_bytes_stream_cut_simplest_field_with_eof_out_of_bounds() {
+        let mut stdout = Vec::new();
+        let mut stdin = b"a".as_slice();
+        let mut opt = make_fields_opt();
+        opt.bounds = ForwardBounds::from_str("2").unwrap();
+        let last_interesting_field = opt.bounds.get_last_bound().r;
+
+        let res = cut_bytes_stream(&mut stdin, &mut stdout, &opt, last_interesting_field);
+        let error = res.unwrap_err();
+        assert_eq!(format!("{}", error), "Out of bounds: 2");
+    }
+
+    #[test]
+    fn test_cut_bytes_stream_only_fillers_and_fallbacks() {
+        let mut stdout = Vec::new();
+        let mut stdin = b"a".as_slice();
+        let mut opt = make_fields_opt();
+        opt.bounds = ForwardBounds::from_str("foo-{2=waitforit}-bar").unwrap();
+        let last_interesting_field = opt.bounds.get_last_bound().r;
+
+        cut_bytes_stream(&mut stdin, &mut stdout, &opt, last_interesting_field).unwrap();
+
+        assert_eq!(
+            stdout.to_str_lossy(),
+            b"foo-waitforit-bar\n".as_slice().to_str_lossy()
+        );
+    }
+
+    #[test]
+    fn test_cut_bytes_stream_cut_multiple_fields_with_range_right_unlimited_case_1() {
+        let mut stdout = Vec::new();
+        let mut stdin = b"a-b-c".as_slice();
+        let mut opt = make_fields_opt();
+        opt.bounds = ForwardBounds::from_str("1:").unwrap();
+        let last_interesting_field = opt.bounds.get_last_bound().r;
+
+        cut_bytes_stream(&mut stdin, &mut stdout, &opt, last_interesting_field).unwrap();
+
+        assert_eq!(stdout.to_str_lossy(), b"a-b-c\n".as_slice().to_str_lossy());
+    }
+
+    #[test]
+    fn test_cut_bytes_stream_cut_multiple_fields_with_range_right_unlimited_case_2() {
+        let mut stdout = Vec::new();
+        let mut stdin = b"a-b-c".as_slice();
+        let mut opt = make_fields_opt();
+        opt.bounds = ForwardBounds::from_str("2:").unwrap();
+        let last_interesting_field = opt.bounds.get_last_bound().r;
+
+        cut_bytes_stream(&mut stdin, &mut stdout, &opt, last_interesting_field).unwrap();
+
+        assert_eq!(stdout.to_str_lossy(), b"b-c\n".as_slice().to_str_lossy());
+    }
+
+    #[test]
+    fn test_cut_bytes_stream_cut_multiple_fields_with_range_left_unlimited_case_1() {
+        let mut stdout = Vec::new();
+        let mut stdin = b"a-b-c".as_slice();
+        let mut opt = make_fields_opt();
+        opt.bounds = ForwardBounds::from_str(":1").unwrap();
+        let last_interesting_field = opt.bounds.get_last_bound().r;
+
+        cut_bytes_stream(&mut stdin, &mut stdout, &opt, last_interesting_field).unwrap();
+
+        assert_eq!(stdout.to_str_lossy(), b"a\n".as_slice().to_str_lossy());
+    }
+
+    #[test]
+    fn test_cut_bytes_stream_cut_multiple_fields_with_range_left_unlimited_case_2() {
+        let mut stdout = Vec::new();
+        let mut stdin = b"a-b-c".as_slice();
+        let mut opt = make_fields_opt();
+        opt.bounds = ForwardBounds::from_str(":2").unwrap();
+        let last_interesting_field = opt.bounds.get_last_bound().r;
+
+        cut_bytes_stream(&mut stdin, &mut stdout, &opt, last_interesting_field).unwrap();
+
+        assert_eq!(stdout.to_str_lossy(), b"a-b\n".as_slice().to_str_lossy());
+    }
+
+    #[test]
+    fn test_cut_bytes_stream_cut_multiple_fields_with_range_right_unlimited() {
+        let mut stdout = Vec::new();
+        let mut stdin = b"a-b-c".as_slice();
+        let mut opt = make_fields_opt();
+        opt.bounds = ForwardBounds::from_str("2:").unwrap();
+        let last_interesting_field = opt.bounds.get_last_bound().r;
+
+        cut_bytes_stream(&mut stdin, &mut stdout, &opt, last_interesting_field).unwrap();
+
+        assert_eq!(stdout.to_str_lossy(), b"b-c\n".as_slice().to_str_lossy());
+    }
+
+    #[test]
+    fn test_cut_bytes_stream_cut_multiple_fields_no_eol() {
+        let mut stdout = Vec::new();
+        let mut stdin = b"a-b".as_slice();
+        let mut opt = make_fields_opt();
+        opt.bounds = ForwardBounds::from_str("1,2").unwrap();
+        let last_interesting_field = opt.bounds.get_last_bound().r;
+
+        cut_bytes_stream(&mut stdin, &mut stdout, &opt, last_interesting_field).unwrap();
+
+        assert_eq!(stdout.to_str_lossy(), b"ab\n".as_slice().to_str_lossy());
+    }
+
+    #[test]
+    fn test_cut_bytes_stream_cut_multiple_fields_with_eol() {
+        let mut stdout = Vec::new();
+        let mut stdin = b"a-b\n".as_slice();
+        let mut opt = make_fields_opt();
+        opt.bounds = ForwardBounds::from_str("1,2").unwrap();
+        let last_interesting_field = opt.bounds.get_last_bound().r;
+
+        cut_bytes_stream(&mut stdin, &mut stdout, &opt, last_interesting_field).unwrap();
+
+        assert_eq!(stdout.to_str_lossy(), b"ab\n".as_slice().to_str_lossy());
+    }
+
+    #[test]
+    fn test_cut_bytes_stream_cut_multiple_fields_keep_few_no_eol() {
+        let mut stdout = Vec::new();
+        let mut stdin = b"a-b-c".as_slice();
+        let mut opt = make_fields_opt();
+        opt.bounds = ForwardBounds::from_str("1,2").unwrap();
+        let last_interesting_field = opt.bounds.get_last_bound().r;
+
+        cut_bytes_stream(&mut stdin, &mut stdout, &opt, last_interesting_field).unwrap();
+
+        assert_eq!(stdout.to_str_lossy(), b"ab\n".as_slice().to_str_lossy());
+    }
+
+    #[test]
+    fn test_cut_bytes_stream_cut_multiple_fields_keep_few_with_eol() {
+        let mut stdout = Vec::new();
+        let mut stdin = b"a-b-c\n".as_slice();
+        let mut opt = make_fields_opt();
+        opt.bounds = ForwardBounds::from_str("1,2").unwrap();
+        let last_interesting_field = opt.bounds.get_last_bound().r;
+
+        cut_bytes_stream(&mut stdin, &mut stdout, &opt, last_interesting_field).unwrap();
+
+        assert_eq!(stdout.to_str_lossy(), b"ab\n".as_slice().to_str_lossy());
+    }
+
+    #[test]
+    fn test_cut_bytes_stream_cut_multiple_fields_with_eol_small_buffer_dropped_fields() {
+        let mut stdout = Vec::new();
+        let stdin_content = b"a-b-c-d-e-f\ng-h-i-l-m\n".as_slice();
+        let mut stdin = BufReader::with_capacity(3, stdin_content);
+        let mut opt = make_fields_opt();
+        opt.bounds = ForwardBounds::from_str("1,2").unwrap();
+        let last_interesting_field = opt.bounds.get_last_bound().r;
+
+        cut_bytes_stream(&mut stdin, &mut stdout, &opt, last_interesting_field).unwrap();
+
+        assert_eq!(stdout.to_str_lossy(), b"ab\ngh\n".as_slice().to_str_lossy());
+    }
+
+    #[test]
+    fn test_cut_bytes_stream_cut_multiple_fields_small_buffer_few_no_eol_with_fallbacks() {
+        let mut stdout = Vec::new();
+        let stdin_content = b"foobar".as_slice();
+        let mut stdin = BufReader::with_capacity(2, stdin_content);
+        let mut opt = make_fields_opt();
+        opt.bounds = ForwardBounds::from_str("{9=fallback}").unwrap();
+        let last_interesting_field = opt.bounds.get_last_bound().r;
+
+        cut_bytes_stream(&mut stdin, &mut stdout, &opt, last_interesting_field).unwrap();
+
+        assert_eq!(
+            stdout.to_str_lossy(),
+            b"fallback\n".as_slice().to_str_lossy()
+        );
+    }
+
+    #[test]
+    fn test_cut_bytes_stream_cut_multiple_fields_small_buffer_few_with_eol_with_fallbacks() {
+        let mut stdout = Vec::new();
+        let stdin_content = b"foobar\n".as_slice();
+        let mut stdin = BufReader::with_capacity(2, stdin_content);
+        let mut opt = make_fields_opt();
+        opt.bounds = ForwardBounds::from_str("{9=fallback}").unwrap();
+        let last_interesting_field = opt.bounds.get_last_bound().r;
+
+        cut_bytes_stream(&mut stdin, &mut stdout, &opt, last_interesting_field).unwrap();
+
+        assert_eq!(
+            stdout.to_str_lossy(),
+            b"fallback\n".as_slice().to_str_lossy()
+        );
+    }
+
+    #[test]
+    fn test_cut_bytes_stream_cut_simplest_field_multiline_with_eol() {
+        let mut stdout = Vec::new();
+        let mut stdin = b"a\nb\n".as_slice();
+        let mut opt = make_fields_opt();
+        opt.bounds = ForwardBounds::from_str("1").unwrap();
+        let last_interesting_field = opt.bounds.get_last_bound().r;
+
+        cut_bytes_stream(&mut stdin, &mut stdout, &opt, last_interesting_field).unwrap();
+
+        assert_eq!(stdout.to_str_lossy(), b"a\nb\n".as_slice().to_str_lossy());
+    }
+
+    #[test]
+    fn test_cut_bytes_stream_cut_multiple_fields_multiline_with_eol() {
+        let mut stdout = Vec::new();
+        let mut stdin = b"a-b\nc-d\n".as_slice();
+        let mut opt = make_fields_opt();
+        opt.bounds = ForwardBounds::from_str("1,2").unwrap();
+        let last_interesting_field = opt.bounds.get_last_bound().r;
+
+        cut_bytes_stream(&mut stdin, &mut stdout, &opt, last_interesting_field).unwrap();
+
+        assert_eq!(stdout.to_str_lossy(), b"ab\ncd\n".as_slice().to_str_lossy());
+    }
+
+    #[test]
+    fn test_cut_bytes_stream_cut_multiple_fields_with_join_and_eol() {
+        let mut stdout = Vec::new();
+        let mut stdin = b"a-b\n".as_slice();
+        let mut opt = make_fields_opt();
+        opt.join = true;
+        opt.bounds = ForwardBounds::from_str("1,2").unwrap();
+        let last_interesting_field = opt.bounds.get_last_bound().r;
+
+        cut_bytes_stream(&mut stdin, &mut stdout, &opt, last_interesting_field).unwrap();
+
+        assert_eq!(stdout.to_str_lossy(), b"a-b\n".as_slice().to_str_lossy());
+    }
+
+    #[test]
+    fn test_cut_bytes_stream_multiple_chunks_sizes() {
+        // todo add same test case but with multi-bytes fields (3 bytes fields)
+        let stdin_content = b"a-b\n".as_slice();
+        let mut opt = make_fields_opt();
+        opt.join = true;
+        opt.bounds = ForwardBounds::from_str("1,2").unwrap();
+        let last_interesting_field = opt.bounds.get_last_bound().r;
+
+        let mut stdout = Vec::new();
+        let mut stdin = BufReader::with_capacity(1, stdin_content);
+        cut_bytes_stream(&mut stdin, &mut stdout, &opt, last_interesting_field).unwrap();
+        assert_eq!(stdout.to_str_lossy(), b"a-b\n".as_slice().to_str_lossy());
+
+        let mut stdout = Vec::new();
+        let mut stdin = BufReader::with_capacity(2, stdin_content);
+        cut_bytes_stream(&mut stdin, &mut stdout, &opt, last_interesting_field).unwrap();
+        assert_eq!(stdout.to_str_lossy(), b"a-b\n".as_slice().to_str_lossy());
+
+        let mut stdout = Vec::new();
+        let mut stdin = BufReader::with_capacity(3, stdin_content);
+        cut_bytes_stream(&mut stdin, &mut stdout, &opt, last_interesting_field).unwrap();
+        assert_eq!(stdout.to_str_lossy(), b"a-b\n".as_slice().to_str_lossy());
+
+        let mut stdout = Vec::new();
+        let mut stdin = BufReader::with_capacity(4, stdin_content);
+        cut_bytes_stream(&mut stdin, &mut stdout, &opt, last_interesting_field).unwrap();
+        assert_eq!(stdout.to_str_lossy(), b"a-b\n".as_slice().to_str_lossy());
+    }
+
+    #[test]
+    fn test_cut_bytes_stream_it_supports_ranges() {
+        let mut stdout = Vec::new();
+        let mut stdin = b"a-b-c".as_slice();
+        let mut opt = make_fields_opt();
+        opt.bounds = ForwardBounds::from_str("1:2,3").unwrap();
+        let last_interesting_field = opt.bounds.get_last_bound().r;
+
+        cut_bytes_stream(&mut stdin, &mut stdout, &opt, last_interesting_field).unwrap();
+
+        assert_eq!(stdout.to_str_lossy(), b"a-bc\n".as_slice().to_str_lossy());
+    }
+
+    #[test]
+    fn test_cut_bytes_stream_it_supports_ranges_with_join_case_1() {
+        let mut stdout = Vec::new();
+        let mut stdin = b"a-b-c".as_slice();
+        let mut opt = make_fields_opt();
+        opt.join = true;
+        opt.bounds = ForwardBounds::from_str("1:2,3").unwrap();
+        let last_interesting_field = opt.bounds.get_last_bound().r;
+
+        cut_bytes_stream(&mut stdin, &mut stdout, &opt, last_interesting_field).unwrap();
+
+        assert_eq!(stdout.to_str_lossy(), b"a-b-c\n".as_slice().to_str_lossy());
+    }
+
+    #[test]
+    fn test_cut_bytes_stream_it_supports_ranges_with_join_case_2() {
+        let mut stdout = Vec::new();
+        let mut stdin = b"a-b-c".as_slice();
+        let mut opt = make_fields_opt();
+        opt.join = true;
+        opt.bounds = ForwardBounds::from_str("1,2:3").unwrap();
+        let last_interesting_field = opt.bounds.get_last_bound().r;
+
+        cut_bytes_stream(&mut stdin, &mut stdout, &opt, last_interesting_field).unwrap();
+
+        assert_eq!(stdout.to_str_lossy(), b"a-b-c\n".as_slice().to_str_lossy());
+    }
+
+    #[test]
+    fn test_cut_bytes_stream_it_supports_replacing_delimiter_case_1() {
+        let mut stdout = Vec::new();
+        let mut stdin = b"a-b-c".as_slice();
+        let mut opt = make_fields_opt();
+        opt.join = true;
+        opt.replace_delimiter = Some(b'/');
+        opt.bounds = ForwardBounds::from_str("1,2:3").unwrap();
+        let last_interesting_field = opt.bounds.get_last_bound().r;
+
+        cut_bytes_stream(&mut stdin, &mut stdout, &opt, last_interesting_field).unwrap();
+
+        assert_eq!(stdout.to_str_lossy(), b"a/b/c\n".as_slice().to_str_lossy());
+    }
+    #[test]
+    fn test_cut_bytes_stream_it_supports_replacing_delimiter_case_2() {
+        let mut stdout = Vec::new();
+        let mut stdin = b"a-b-c".as_slice();
+        let mut opt = make_fields_opt();
+        opt.join = true;
+        opt.replace_delimiter = Some(b'/');
+        opt.bounds = ForwardBounds::from_str("1,2:").unwrap();
+        let last_interesting_field = opt.bounds.get_last_bound().r;
+
+        cut_bytes_stream(&mut stdin, &mut stdout, &opt, last_interesting_field).unwrap();
+
+        assert_eq!(stdout.to_str_lossy(), b"a/b/c\n".as_slice().to_str_lossy());
+    }
+}

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -399,6 +399,32 @@ mod tests {
     }
 
     #[test]
+    fn test_try_from_valid_forward_bounds() {
+        let bounds = UserBoundsList::from_str("1,2,3:5").unwrap();
+        assert!(ForwardBounds::try_from(&bounds).is_ok());
+    }
+
+    #[test]
+    fn test_try_from_repeated_bounds() {
+        let bounds = UserBoundsList::from_str("1,2,2,3").unwrap();
+        let error = ForwardBounds::try_from(&bounds).unwrap_err();
+        assert_eq!(
+            format!("{}", error),
+            "Bounds are sorted, but can't be repeated"
+        );
+    }
+
+    #[test]
+    fn test_try_from_non_forward_bounds() {
+        let bounds = UserBoundsList::from_str("1,3,2").unwrap();
+        let error = ForwardBounds::try_from(&bounds).unwrap_err();
+        assert_eq!(
+            format!("{}", error),
+            "The provided UserBoundsList is not forward only"
+        );
+    }
+
+    #[test]
     fn test_cut_bytes_stream_cut_simplest_field_no_eol() {
         let mut stdout = Vec::new();
         let mut stdin = b"a".as_slice();

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -537,3 +537,43 @@ fn it_cannot_format_fields_alongside_json() {
         .failure()
         .stderr("tuc: runtime error. Cannot format fields when using --json\n");
 }
+
+#[test]
+fn it_accept_fixed_memory_option() {
+    let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+
+    let assert = cmd
+        .args(["-d", "-", "-f", "2", "-M", "1"])
+        .write_stdin("ab-cd")
+        .assert();
+
+    assert.success().stdout("cd\n");
+}
+
+#[test]
+fn it_fails_if_fixed_memory_option_is_used_with_unsupported_fields() {
+    let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+
+    let assert = cmd
+        .args(["-d", "-", "-f", "2", "-M", "1", "--json"])
+        .write_stdin("ab-cd")
+        .assert();
+
+    assert
+        .failure()
+        .stderr("tuc: runtime error. StreamOpt supports solely forward fields, join and single-character delimiters\n");
+}
+
+#[test]
+fn it_fails_if_fixed_memory_value_is_zero() {
+    let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+
+    let assert = cmd
+        .args(["-d", "-", "-f", "2", "-M", "0"])
+        .write_stdin("ab-cd")
+        .assert();
+
+    assert
+        .failure()
+        .stderr("tuc: runtime error. --fixed-memory cannot be 0\n");
+}


### PR DESCRIPTION
We do already stream data, with a caveat: we keep each line in memory. If a single line were to exceed the amount of memory we can allocate, tuc would crash (and before that happens your computer wouldn't be too happy).

In some scenarios we can use a pure streaming algorithm that does not buffer lines. Among other things that we can't support when we use the streaming alg is that we won't support negative indices for fields (because that require to read the line first). Other options too won't be available. As for "fast lane", we will use this route only if the options provided by the user allows it.