### PR TITLE
Improve bounds match

### DIFF
--- a/src/bin/tuc.rs
+++ b/src/bin/tuc.rs
@@ -114,7 +114,7 @@ fn parse_args() -> Result<Opt, pico_args::Error> {
     };
 
     if bounds_type == BoundsType::Fields
-        && (maybe_fields.is_none() || maybe_fields.as_ref().unwrap().0.is_empty())
+        && (maybe_fields.is_none() || maybe_fields.as_ref().unwrap().is_empty())
     {
         eprintln!("tuc: invariant error. At this point we expected to find at least 1 field bound");
         std::process::exit(1);
@@ -209,12 +209,7 @@ fn parse_args() -> Result<Opt, pico_args::Error> {
         .or(maybe_lines)
         .unwrap();
 
-    if has_json
-        && bounds
-            .0
-            .iter()
-            .any(|s| matches!(s, BoundOrFiller::Filler(_)))
-    {
+    if has_json && bounds.iter().any(|s| matches!(s, BoundOrFiller::Filler(_))) {
         eprintln!("tuc: runtime error. Cannot format fields when using --json");
         std::process::exit(1);
     }

--- a/src/bounds.rs
+++ b/src/bounds.rs
@@ -101,7 +101,7 @@ pub struct UserBoundsList {
     /// Optimization that we can use to stop searching for fields.
     /// It's available only when every bound uses positive indexes.
     /// When conditions do not apply, its value is `Side::Continue`.
-    last_interesting_field: Side,
+    pub last_interesting_field: Side,
 }
 
 impl Deref for UserBoundsList {
@@ -122,8 +122,8 @@ impl From<Vec<BoundOrFiller>> for UserBoundsList {
         let mut rightmost_bound: Option<Side> = None;
 
         // This is risky, we could end up using last_interesting_field
-        // internally. Couldn't figure out how to use is_sortable without
-        //  major refactoring.
+        // internally. Didn't spend much time to figure out how to use
+        // is_sortable without major refactoring.
         if ubl.is_sortable() {
             ubl.list.iter().for_each(|bof| {
                 if let BoundOrFiller::Bound(b) = bof {
@@ -241,10 +241,6 @@ impl UserBoundsList {
             .collect();
 
         list.into()
-    }
-
-    pub fn get_last_bound(&self) -> Side {
-        self.last_interesting_field
     }
 }
 

--- a/src/cut_bytes.rs
+++ b/src/cut_bytes.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use std::io::{Read, Write};
 
-use crate::bounds::BoundOrFiller;
+use crate::bounds::{BoundOrFiller, UserBoundsTrait};
 use crate::options::Opt;
 use crate::read_utils::read_bytes_to_end;
 

--- a/src/cut_bytes.rs
+++ b/src/cut_bytes.rs
@@ -10,7 +10,7 @@ fn cut_bytes<W: Write>(data: &[u8], opt: &Opt, stdout: &mut W) -> Result<()> {
         return Ok(());
     }
 
-    opt.bounds.0.iter().try_for_each(|bof| -> Result<()> {
+    opt.bounds.iter().try_for_each(|bof| -> Result<()> {
         let output = match bof {
             BoundOrFiller::Bound(b) => {
                 let r = b.try_into_range(data.len())?;

--- a/src/cut_lines.rs
+++ b/src/cut_lines.rs
@@ -147,40 +147,28 @@ mod tests {
         }
     }
 
-    const BOF_F1: BoundOrFiller = BoundOrFiller::Bound(UserBounds {
-        l: Side::Some(1),
-        r: Side::Some(1),
-    });
+    const BOF_F1: BoundOrFiller =
+        BoundOrFiller::Bound(UserBounds::new(Side::Some(1), Side::Some(1)));
 
-    const BOF_F2: BoundOrFiller = BoundOrFiller::Bound(UserBounds {
-        l: Side::Some(2),
-        r: Side::Some(2),
-    });
+    const BOF_F2: BoundOrFiller =
+        BoundOrFiller::Bound(UserBounds::new(Side::Some(2), Side::Some(2)));
 
-    const BOF_F3: BoundOrFiller = BoundOrFiller::Bound(UserBounds {
-        l: Side::Some(3),
-        r: Side::Some(3),
-    });
+    const BOF_F3: BoundOrFiller =
+        BoundOrFiller::Bound(UserBounds::new(Side::Some(3), Side::Some(3)));
 
-    const BOF_R2_3: BoundOrFiller = BoundOrFiller::Bound(UserBounds {
-        l: Side::Some(2),
-        r: Side::Some(3),
-    });
+    const BOF_R2_3: BoundOrFiller =
+        BoundOrFiller::Bound(UserBounds::new(Side::Some(2), Side::Some(3)));
 
-    const BOF_NEG1: BoundOrFiller = BoundOrFiller::Bound(UserBounds {
-        l: Side::Some(-1),
-        r: Side::Some(-1),
-    });
+    const BOF_NEG1: BoundOrFiller =
+        BoundOrFiller::Bound(UserBounds::new(Side::Some(-1), Side::Some(-1)));
 
-    const BOF_F1_TO_END: BoundOrFiller = BoundOrFiller::Bound(UserBounds {
-        l: Side::Some(1),
-        r: Side::Continue,
-    });
+    const BOF_F1_TO_END: BoundOrFiller =
+        BoundOrFiller::Bound(UserBounds::new(Side::Some(1), Side::Continue));
 
     #[test]
     fn fwd_cut_one_field() {
         let mut opt = make_lines_opt();
-        opt.bounds = UserBoundsList(vec![BOF_F1]);
+        opt.bounds = UserBoundsList::new(vec![BOF_F1]);
 
         let mut input = b"a\nb".as_slice();
         let mut output = Vec::with_capacity(100);
@@ -191,7 +179,7 @@ mod tests {
     #[test]
     fn fwd_cut_multiple_fields() {
         let mut opt = make_lines_opt();
-        opt.bounds = UserBoundsList(vec![BOF_F1, BOF_F2]);
+        opt.bounds = UserBoundsList::new(vec![BOF_F1, BOF_F2]);
 
         let mut input = b"a\nb".as_slice();
         let mut output = Vec::with_capacity(100);
@@ -202,7 +190,7 @@ mod tests {
     #[test]
     fn fwd_support_ranges() {
         let mut opt = make_lines_opt();
-        opt.bounds = UserBoundsList(vec![BOF_F1, BOF_R2_3]);
+        opt.bounds = UserBoundsList::new(vec![BOF_F1, BOF_R2_3]);
 
         let mut input = b"a\nb\nc".as_slice();
         let mut output = Vec::with_capacity(100);
@@ -213,7 +201,7 @@ mod tests {
     #[test]
     fn fwd_supports_no_join() {
         let mut opt = make_lines_opt();
-        opt.bounds = UserBoundsList(vec![BOF_F1, BOF_F3]);
+        opt.bounds = UserBoundsList::new(vec![BOF_F1, BOF_F3]);
         opt.join = false;
 
         let mut input = b"a\nb\nc".as_slice();
@@ -225,7 +213,7 @@ mod tests {
     #[test]
     fn fwd_supports_no_right_bound() {
         let mut opt = make_lines_opt();
-        opt.bounds = UserBoundsList(vec![BOF_F1_TO_END]);
+        opt.bounds = UserBoundsList::new(vec![BOF_F1_TO_END]);
 
         let mut input = b"a\nb".as_slice();
         let mut output = Vec::with_capacity(100);
@@ -236,7 +224,7 @@ mod tests {
     #[test]
     fn fwd_handle_out_of_bounds() {
         let mut opt = make_lines_opt();
-        opt.bounds = UserBoundsList(vec![BOF_F3]);
+        opt.bounds = UserBoundsList::new(vec![BOF_F3]);
         opt.join = true;
 
         let mut input = b"a\nb".as_slice();
@@ -248,7 +236,7 @@ mod tests {
     #[test]
     fn fwd_ignore_last_empty() {
         let mut opt = make_lines_opt();
-        opt.bounds = UserBoundsList(vec![BOF_F3]);
+        opt.bounds = UserBoundsList::new(vec![BOF_F3]);
 
         let mut input1 = b"a\nb".as_slice();
         let mut input2 = b"a\nb\n".as_slice();
@@ -266,7 +254,7 @@ mod tests {
     #[test]
     fn cut_lines_handle_negative_idx() {
         let mut opt = make_lines_opt();
-        opt.bounds = UserBoundsList(vec![BOF_NEG1]);
+        opt.bounds = UserBoundsList::new(vec![BOF_NEG1]);
 
         let mut input = b"a\nb".as_slice();
         let mut output = Vec::with_capacity(100);
@@ -277,7 +265,7 @@ mod tests {
     #[test]
     fn cut_lines_ignore_last_empty_when_using_positive_idx() {
         let mut opt = make_lines_opt();
-        opt.bounds = UserBoundsList(vec![BOF_F3]);
+        opt.bounds = UserBoundsList::new(vec![BOF_F3]);
 
         let mut input1 = b"a\nb".as_slice();
         let mut input2 = b"a\nb\n".as_slice();
@@ -295,7 +283,7 @@ mod tests {
     #[test]
     fn cut_lines_ignore_last_empty_when_using_negative_idx() {
         let mut opt = make_lines_opt();
-        opt.bounds = UserBoundsList(vec![BOF_NEG1]);
+        opt.bounds = UserBoundsList::new(vec![BOF_NEG1]);
 
         let mut input1 = b"a\nb".as_slice();
         let mut input2 = b"a\nb\n".as_slice();
@@ -313,7 +301,7 @@ mod tests {
     #[test]
     fn fwd_cut_zero_delimited() {
         let mut opt = make_lines_opt();
-        opt.bounds = UserBoundsList(vec![BOF_F1]);
+        opt.bounds = UserBoundsList::new(vec![BOF_F1]);
         opt.eol = EOL::Zero;
         opt.delimiter = String::from("\0");
 
@@ -326,7 +314,7 @@ mod tests {
     #[test]
     fn cut_lines_zero_delimited() {
         let mut opt = make_lines_opt();
-        opt.bounds = UserBoundsList(vec![BOF_F1]);
+        opt.bounds = UserBoundsList::new(vec![BOF_F1]);
         opt.eol = EOL::Zero;
         opt.delimiter = String::from("\0");
 

--- a/src/cut_lines.rs
+++ b/src/cut_lines.rs
@@ -131,8 +131,10 @@ pub fn read_and_cut_lines<A: BufRead, B: Write>(
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
     use crate::{
-        bounds::{BoundsType, UserBounds, UserBoundsList},
+        bounds::{BoundsType, UserBoundsList},
         options::EOL,
     };
 
@@ -147,29 +149,10 @@ mod tests {
         }
     }
 
-    fn bof_f1() -> BoundOrFiller {
-        BoundOrFiller::Bound(UserBounds::new(Side::Some(1), Side::Some(1)))
-    }
-
-    fn bof_f2() -> BoundOrFiller {
-        BoundOrFiller::Bound(UserBounds::new(Side::Some(2), Side::Some(2)))
-    }
-    fn bof_f3() -> BoundOrFiller {
-        BoundOrFiller::Bound(UserBounds::new(Side::Some(3), Side::Some(3)))
-    }
-    fn bof_r2_3() -> BoundOrFiller {
-        BoundOrFiller::Bound(UserBounds::new(Side::Some(2), Side::Some(3)))
-    }
-    fn bof_neg1() -> BoundOrFiller {
-        BoundOrFiller::Bound(UserBounds::new(Side::Some(-1), Side::Some(-1)))
-    }
-    fn bof_f1_to_end() -> BoundOrFiller {
-        BoundOrFiller::Bound(UserBounds::new(Side::Some(1), Side::Continue))
-    }
     #[test]
     fn fwd_cut_one_field() {
         let mut opt = make_lines_opt();
-        opt.bounds = UserBoundsList::new(vec![bof_f1()]);
+        opt.bounds = UserBoundsList::from_str("1").unwrap();
 
         let mut input = b"a\nb".as_slice();
         let mut output = Vec::with_capacity(100);
@@ -180,7 +163,7 @@ mod tests {
     #[test]
     fn fwd_cut_multiple_fields() {
         let mut opt = make_lines_opt();
-        opt.bounds = UserBoundsList::new(vec![bof_f1(), bof_f2()]);
+        opt.bounds = UserBoundsList::from_str("1:2").unwrap();
 
         let mut input = b"a\nb".as_slice();
         let mut output = Vec::with_capacity(100);
@@ -191,7 +174,7 @@ mod tests {
     #[test]
     fn fwd_support_ranges() {
         let mut opt = make_lines_opt();
-        opt.bounds = UserBoundsList::new(vec![bof_f1(), bof_r2_3()]);
+        opt.bounds = UserBoundsList::from_str("1,2:3").unwrap();
 
         let mut input = b"a\nb\nc".as_slice();
         let mut output = Vec::with_capacity(100);
@@ -202,7 +185,7 @@ mod tests {
     #[test]
     fn fwd_supports_no_join() {
         let mut opt = make_lines_opt();
-        opt.bounds = UserBoundsList::new(vec![bof_f1(), bof_f3()]);
+        opt.bounds = UserBoundsList::from_str("1,3").unwrap();
         opt.join = false;
 
         let mut input = b"a\nb\nc".as_slice();
@@ -214,7 +197,7 @@ mod tests {
     #[test]
     fn fwd_supports_no_right_bound() {
         let mut opt = make_lines_opt();
-        opt.bounds = UserBoundsList::new(vec![bof_f1_to_end()]);
+        opt.bounds = UserBoundsList::from_str("1:").unwrap();
 
         let mut input = b"a\nb".as_slice();
         let mut output = Vec::with_capacity(100);
@@ -225,7 +208,7 @@ mod tests {
     #[test]
     fn fwd_handle_out_of_bounds() {
         let mut opt = make_lines_opt();
-        opt.bounds = UserBoundsList::new(vec![bof_f3()]);
+        opt.bounds = UserBoundsList::from_str("3").unwrap();
         opt.join = true;
 
         let mut input = b"a\nb".as_slice();
@@ -237,7 +220,7 @@ mod tests {
     #[test]
     fn fwd_ignore_last_empty() {
         let mut opt = make_lines_opt();
-        opt.bounds = UserBoundsList::new(vec![bof_f3()]);
+        opt.bounds = UserBoundsList::from_str("3").unwrap();
 
         let mut input1 = b"a\nb".as_slice();
         let mut input2 = b"a\nb\n".as_slice();
@@ -255,7 +238,7 @@ mod tests {
     #[test]
     fn cut_lines_handle_negative_idx() {
         let mut opt = make_lines_opt();
-        opt.bounds = UserBoundsList::new(vec![bof_neg1()]);
+        opt.bounds = UserBoundsList::from_str("-1").unwrap();
 
         let mut input = b"a\nb".as_slice();
         let mut output = Vec::with_capacity(100);
@@ -266,7 +249,7 @@ mod tests {
     #[test]
     fn cut_lines_ignore_last_empty_when_using_positive_idx() {
         let mut opt = make_lines_opt();
-        opt.bounds = UserBoundsList::new(vec![bof_f3()]);
+        opt.bounds = UserBoundsList::from_str("3").unwrap();
 
         let mut input1 = b"a\nb".as_slice();
         let mut input2 = b"a\nb\n".as_slice();
@@ -284,7 +267,7 @@ mod tests {
     #[test]
     fn cut_lines_ignore_last_empty_when_using_negative_idx() {
         let mut opt = make_lines_opt();
-        opt.bounds = UserBoundsList::new(vec![bof_neg1()]);
+        opt.bounds = UserBoundsList::from_str("-1").unwrap();
 
         let mut input1 = b"a\nb".as_slice();
         let mut input2 = b"a\nb\n".as_slice();
@@ -302,7 +285,7 @@ mod tests {
     #[test]
     fn fwd_cut_zero_delimited() {
         let mut opt = make_lines_opt();
-        opt.bounds = UserBoundsList::new(vec![bof_f1()]);
+        opt.bounds = UserBoundsList::from_str("1").unwrap();
         opt.eol = EOL::Zero;
         opt.delimiter = String::from("\0");
 
@@ -315,7 +298,7 @@ mod tests {
     #[test]
     fn cut_lines_zero_delimited() {
         let mut opt = make_lines_opt();
-        opt.bounds = UserBoundsList::new(vec![bof_f1()]);
+        opt.bounds = UserBoundsList::from_str("1").unwrap();
         opt.eol = EOL::Zero;
         opt.delimiter = String::from("\0");
 

--- a/src/cut_str.rs
+++ b/src/cut_str.rs
@@ -313,7 +313,8 @@ pub fn cut_str<W: Write>(
                 b,
                 BoundOrFiller::Bound(UserBounds {
                     l: x,
-                    r: y
+                    r: y,
+                    is_last: _,
                 }) if x != y || x == &Side::Continue
             )
         }) {

--- a/src/cut_str.rs
+++ b/src/cut_str.rs
@@ -2,7 +2,7 @@ use anyhow::{bail, Result};
 use std::io::{BufRead, Write};
 use std::ops::Range;
 
-use crate::bounds::{BoundOrFiller, BoundsType, Side, UserBounds, UserBoundsList};
+use crate::bounds::{BoundOrFiller, BoundsType, Side, UserBounds, UserBoundsList, UserBoundsTrait};
 use crate::json::escape_json;
 use crate::options::{Opt, Trim};
 use crate::read_utils::read_line_with_eol;

--- a/src/fast_lane.rs
+++ b/src/fast_lane.rs
@@ -1,4 +1,4 @@
-use crate::bounds::{BoundOrFiller, BoundsType, Side, UserBounds, UserBoundsList};
+use crate::bounds::{BoundOrFiller, BoundsType, Side, UserBounds, UserBoundsList, UserBoundsTrait};
 use crate::options::{Opt, Trim, EOL};
 use anyhow::Result;
 use bstr::ByteSlice;

--- a/src/fast_lane.rs
+++ b/src/fast_lane.rs
@@ -82,22 +82,17 @@ fn cut_str_fast_lane<W: Write>(
             stdout.write_all(buffer)?;
         }
         _ => {
-            bounds
-                .iter()
-                .enumerate()
-                .try_for_each(|(bounds_idx, bof)| -> Result<()> {
-                    match bof {
-                        BoundOrFiller::Filler(f) => {
-                            stdout.write_all(f.as_bytes())?;
-                        }
-                        BoundOrFiller::Bound(b) => {
-                            let is_last = bounds_idx == bounds.len() - 1;
-
-                            output_parts(buffer, b, fields, stdout, is_last, opt)?;
-                        }
-                    };
-                    Ok(())
-                })?;
+            bounds.iter().try_for_each(|bof| -> Result<()> {
+                match bof {
+                    BoundOrFiller::Filler(f) => {
+                        stdout.write_all(f.as_bytes())?;
+                    }
+                    BoundOrFiller::Bound(b) => {
+                        output_parts(buffer, b, fields, stdout, opt)?;
+                    }
+                };
+                Ok(())
+            })?;
         }
     }
 
@@ -114,7 +109,6 @@ fn output_parts<W: Write>(
     // where to find the parts inside `line`
     fields: &[Range<usize>],
     stdout: &mut W,
-    is_last: bool,
     opt: &FastOpt,
 ) -> Result<()> {
     let r = b.try_into_range(fields.len())?;
@@ -126,7 +120,7 @@ fn output_parts<W: Write>(
     let field_to_print = output;
     stdout.write_all(field_to_print)?;
 
-    if opt.join && !(is_last) {
+    if opt.join && !b.is_last {
         stdout.write_all(&[opt.delimiter])?;
     }
 

--- a/src/fast_lane.rs
+++ b/src/fast_lane.rs
@@ -4,7 +4,6 @@ use anyhow::Result;
 use bstr::ByteSlice;
 use std::convert::TryFrom;
 use std::io::{self, BufRead};
-use std::str::FromStr;
 use std::{io::Write, ops::Range};
 
 use bstr::io::BufReadExt;
@@ -135,32 +134,19 @@ fn output_parts<W: Write>(
 }
 
 #[derive(Debug)]
-pub struct FastOpt {
+pub struct FastOpt<'a> {
     delimiter: u8,
     join: bool,
     eol: EOL,
-    bounds: UserBoundsList,
+    bounds: &'a UserBoundsList,
     only_delimited: bool,
     trim: Option<Trim>,
 }
 
-impl Default for FastOpt {
-    fn default() -> Self {
-        Self {
-            delimiter: b'\t',
-            join: false,
-            eol: EOL::Newline,
-            bounds: UserBoundsList::from_str("1:").unwrap(),
-            only_delimited: false,
-            trim: None,
-        }
-    }
-}
-
-impl TryFrom<&Opt> for FastOpt {
+impl<'a> TryFrom<&'a Opt> for FastOpt<'a> {
     type Error = &'static str;
 
-    fn try_from(value: &Opt) -> Result<Self, Self::Error> {
+    fn try_from(value: &'a Opt) -> Result<Self, Self::Error> {
         if value.delimiter.as_bytes().len() != 1 {
             return Err("Delimiter must be 1 byte wide for FastOpt");
         }
@@ -183,7 +169,7 @@ impl TryFrom<&Opt> for FastOpt {
             delimiter,
             join: value.join,
             eol: value.eol,
-            bounds: value.bounds.clone(),
+            bounds: &value.bounds,
             only_delimited: value.only_delimited,
             trim: value.trim,
         })
@@ -225,10 +211,17 @@ mod tests {
 
     use super::*;
 
-    fn make_fields_opt() -> FastOpt {
+    fn make_fields_opt(bounds_as_text: &str) -> FastOpt<'static> {
+        let boxed_bounds = Box::new(UserBoundsList::from_str(bounds_as_text).unwrap());
+        let bounds: &'static mut UserBoundsList = Box::leak(boxed_bounds);
+
         FastOpt {
             delimiter: b'-',
-            ..FastOpt::default()
+            join: false,
+            eol: EOL::Newline,
+            bounds,
+            only_delimited: false,
+            trim: None,
         }
     }
 
@@ -237,7 +230,7 @@ mod tests {
         // read_and_cut_str is difficult to test, let's verify at least
         // that it reads the input and appears to call cut_str
 
-        let opt = make_fields_opt();
+        let opt = make_fields_opt("1:");
         let mut input = b"foo".as_slice();
         let mut output = Vec::new();
         read_and_cut_text_as_bytes(&mut input, &mut output, &opt).unwrap();
@@ -266,7 +259,7 @@ mod tests {
 
     #[test]
     fn cut_str_echo_non_delimited_strings() {
-        let opt = make_fields_opt();
+        let opt = make_fields_opt("1:");
 
         // non-empty line missing the delimiter
         let line = b"foo";
@@ -297,7 +290,7 @@ mod tests {
 
     #[test]
     fn cut_str_skip_non_delimited_strings_when_requested() {
-        let mut opt = make_fields_opt();
+        let mut opt = make_fields_opt("1:");
 
         opt.only_delimited = true;
 
@@ -330,11 +323,10 @@ mod tests {
 
     #[test]
     fn cut_str_it_cut_a_field() {
-        let mut opt = make_fields_opt();
+        let opt = make_fields_opt("1");
         let (mut output, mut fields) = make_cut_str_buffers();
 
         let line = b"a-b-c";
-        opt.bounds = UserBoundsList::from_str("1").unwrap();
 
         cut_str_fast_lane(
             line,
@@ -349,12 +341,11 @@ mod tests {
 
     #[test]
     fn cut_str_it_cut_with_negative_indices() {
-        let mut opt = make_fields_opt();
+        // just one negative index
+        let opt = make_fields_opt("-1");
 
         let line = b"a-b-c";
 
-        // just one negative index
-        opt.bounds = UserBoundsList::from_str("-1").unwrap();
         let (mut output, mut fields) = make_cut_str_buffers();
         cut_str_fast_lane(
             line,
@@ -367,7 +358,7 @@ mod tests {
         assert_eq!(output, b"c\n".as_slice());
 
         // multiple negative indices, in forward order
-        opt.bounds = UserBoundsList::from_str("-2,-1").unwrap();
+        let opt = make_fields_opt("-2,-1");
         let (mut output, mut fields) = make_cut_str_buffers();
         cut_str_fast_lane(
             line,
@@ -380,7 +371,7 @@ mod tests {
         assert_eq!(output, b"bc\n".as_slice());
 
         // multiple negative indices, in non-forward order
-        opt.bounds = UserBoundsList::from_str("-1,-2").unwrap();
+        let opt = make_fields_opt("-1,-2");
         let (mut output, mut fields) = make_cut_str_buffers();
         cut_str_fast_lane(
             line,
@@ -395,7 +386,7 @@ mod tests {
         // mix positive and negative indices
         // (this is particularly useful to verify that we don't screw
         // up optimizations on last field to check)
-        opt.bounds = UserBoundsList::from_str("-1,1").unwrap();
+        let opt = make_fields_opt("-1,1");
         let (mut output, mut fields) = make_cut_str_buffers();
         cut_str_fast_lane(
             line,
@@ -410,11 +401,10 @@ mod tests {
 
     #[test]
     fn cut_str_it_cut_consecutive_delimiters() {
-        let mut opt = make_fields_opt();
+        let opt = make_fields_opt("1,3");
         let (mut output, mut fields) = make_cut_str_buffers();
 
         let line = b"a-b-c";
-        opt.bounds = UserBoundsList::from_str("1,3").unwrap();
 
         cut_str_fast_lane(
             line,
@@ -429,12 +419,11 @@ mod tests {
 
     #[test]
     fn cut_str_it_supports_zero_terminated_lines() {
-        let mut opt = make_fields_opt();
+        let mut opt = make_fields_opt("2");
         let (mut output, mut fields) = make_cut_str_buffers();
         opt.eol = EOL::Zero;
 
         let line = b"a-b-c";
-        opt.bounds = UserBoundsList::from_str("2").unwrap();
 
         cut_str_fast_lane(
             line,
@@ -449,11 +438,10 @@ mod tests {
 
     #[test]
     fn cut_str_it_join_fields() {
-        let mut opt = make_fields_opt();
+        let mut opt = make_fields_opt("1,3");
         let (mut output, mut fields) = make_cut_str_buffers();
 
         let line = b"a-b-c";
-        opt.bounds = UserBoundsList::from_str("1,3").unwrap();
         opt.join = true;
 
         cut_str_fast_lane(
@@ -469,11 +457,10 @@ mod tests {
 
     #[test]
     fn cut_str_it_format_fields() {
-        let mut opt = make_fields_opt();
+        let opt = make_fields_opt("{1} < {3} > {2}");
         let (mut output, mut fields) = make_cut_str_buffers();
 
         let line = b"a-b-c";
-        opt.bounds = UserBoundsList::from_str("{1} < {3} > {2}").unwrap();
 
         cut_str_fast_lane(
             line,
@@ -488,12 +475,11 @@ mod tests {
 
     #[test]
     fn cut_str_it_trim_fields() {
-        let mut opt = make_fields_opt();
+        let mut opt = make_fields_opt("1,3,-1");
         let line = b"--a--b--c--";
 
         // check Trim::Both
         opt.trim = Some(Trim::Both);
-        opt.bounds = UserBoundsList::from_str("1,3,-1").unwrap();
 
         let (mut output, mut fields) = make_cut_str_buffers();
         cut_str_fast_lane(
@@ -507,8 +493,8 @@ mod tests {
         assert_eq!(output, b"abc\n".as_slice());
 
         // check Trim::Left
+        let mut opt = make_fields_opt("1,3,-3");
         opt.trim = Some(Trim::Left);
-        opt.bounds = UserBoundsList::from_str("1,3,-3").unwrap();
 
         let (mut output, mut fields) = make_cut_str_buffers();
         cut_str_fast_lane(
@@ -522,8 +508,8 @@ mod tests {
         assert_eq!(output, b"abc\n".as_slice());
 
         // check Trim::Right
+        let mut opt = make_fields_opt("3,5,-1");
         opt.trim = Some(Trim::Right);
-        opt.bounds = UserBoundsList::from_str("3,5,-1").unwrap();
 
         let (mut output, mut fields) = make_cut_str_buffers();
         cut_str_fast_lane(

--- a/src/fast_lane.rs
+++ b/src/fast_lane.rs
@@ -197,7 +197,7 @@ pub fn read_and_cut_text_as_bytes<R: BufRead, W: Write>(
 ) -> Result<()> {
     let mut fields: Vec<Range<usize>> = Vec::with_capacity(16);
 
-    let last_interesting_field = opt.bounds.get_last_bound();
+    let last_interesting_field = opt.bounds.last_interesting_field;
 
     match opt.eol {
         EOL::Newline => stdin.for_byte_line(|line| {
@@ -276,7 +276,7 @@ mod tests {
             &opt,
             &mut output,
             &mut fields,
-            opt.bounds.get_last_bound(),
+            opt.bounds.last_interesting_field,
         )
         .unwrap();
         assert_eq!(output, b"foo\n".as_slice());
@@ -289,7 +289,7 @@ mod tests {
             &opt,
             &mut output,
             &mut fields,
-            opt.bounds.get_last_bound(),
+            opt.bounds.last_interesting_field,
         )
         .unwrap();
         assert_eq!(output, b"\n".as_slice());
@@ -309,7 +309,7 @@ mod tests {
             &opt,
             &mut output,
             &mut fields,
-            opt.bounds.get_last_bound(),
+            opt.bounds.last_interesting_field,
         )
         .unwrap();
         assert_eq!(output, b"".as_slice());
@@ -322,7 +322,7 @@ mod tests {
             &opt,
             &mut output,
             &mut fields,
-            opt.bounds.get_last_bound(),
+            opt.bounds.last_interesting_field,
         )
         .unwrap();
         assert_eq!(output, b"".as_slice());
@@ -341,7 +341,7 @@ mod tests {
             &opt,
             &mut output,
             &mut fields,
-            opt.bounds.get_last_bound(),
+            opt.bounds.last_interesting_field,
         )
         .unwrap();
         assert_eq!(output, b"a\n".as_slice());
@@ -361,7 +361,7 @@ mod tests {
             &opt,
             &mut output,
             &mut fields,
-            opt.bounds.get_last_bound(),
+            opt.bounds.last_interesting_field,
         )
         .unwrap();
         assert_eq!(output, b"c\n".as_slice());
@@ -374,7 +374,7 @@ mod tests {
             &opt,
             &mut output,
             &mut fields,
-            opt.bounds.get_last_bound(),
+            opt.bounds.last_interesting_field,
         )
         .unwrap();
         assert_eq!(output, b"bc\n".as_slice());
@@ -387,7 +387,7 @@ mod tests {
             &opt,
             &mut output,
             &mut fields,
-            opt.bounds.get_last_bound(),
+            opt.bounds.last_interesting_field,
         )
         .unwrap();
         assert_eq!(output, b"cb\n".as_slice());
@@ -402,7 +402,7 @@ mod tests {
             &opt,
             &mut output,
             &mut fields,
-            opt.bounds.get_last_bound(),
+            opt.bounds.last_interesting_field,
         )
         .unwrap();
         assert_eq!(output, b"ca\n".as_slice());
@@ -421,7 +421,7 @@ mod tests {
             &opt,
             &mut output,
             &mut fields,
-            opt.bounds.get_last_bound(),
+            opt.bounds.last_interesting_field,
         )
         .unwrap();
         assert_eq!(output, b"ac\n".as_slice());
@@ -441,7 +441,7 @@ mod tests {
             &opt,
             &mut output,
             &mut fields,
-            opt.bounds.get_last_bound(),
+            opt.bounds.last_interesting_field,
         )
         .unwrap();
         assert_eq!(output, b"b\0".as_slice());
@@ -461,7 +461,7 @@ mod tests {
             &opt,
             &mut output,
             &mut fields,
-            opt.bounds.get_last_bound(),
+            opt.bounds.last_interesting_field,
         )
         .unwrap();
         assert_eq!(output, b"a-c\n".as_slice());
@@ -480,7 +480,7 @@ mod tests {
             &opt,
             &mut output,
             &mut fields,
-            opt.bounds.get_last_bound(),
+            opt.bounds.last_interesting_field,
         )
         .unwrap();
         assert_eq!(output, b"a < c > b\n".as_slice());
@@ -501,7 +501,7 @@ mod tests {
             &opt,
             &mut output,
             &mut fields,
-            opt.bounds.get_last_bound(),
+            opt.bounds.last_interesting_field,
         )
         .unwrap();
         assert_eq!(output, b"abc\n".as_slice());
@@ -516,7 +516,7 @@ mod tests {
             &opt,
             &mut output,
             &mut fields,
-            opt.bounds.get_last_bound(),
+            opt.bounds.last_interesting_field,
         )
         .unwrap();
         assert_eq!(output, b"abc\n".as_slice());
@@ -531,7 +531,7 @@ mod tests {
             &opt,
             &mut output,
             &mut fields,
-            opt.bounds.get_last_bound(),
+            opt.bounds.last_interesting_field,
         )
         .unwrap();
         assert_eq!(output, b"abc\n".as_slice());

--- a/src/fast_lane.rs
+++ b/src/fast_lane.rs
@@ -87,17 +87,17 @@ fn cut_str_fast_lane<W: Write>(
                 .iter()
                 .enumerate()
                 .try_for_each(|(bounds_idx, bof)| -> Result<()> {
-                    let b = match bof {
+                    match bof {
                         BoundOrFiller::Filler(f) => {
                             stdout.write_all(f.as_bytes())?;
-                            return Ok(());
                         }
-                        BoundOrFiller::Bound(b) => b,
+                        BoundOrFiller::Bound(b) => {
+                            let is_last = bounds_idx == bounds.len() - 1;
+
+                            output_parts(buffer, b, fields, stdout, is_last, opt)?;
+                        }
                     };
-
-                    let is_last = bounds_idx == bounds.len() - 1;
-
-                    output_parts(buffer, b, fields, stdout, is_last, opt)
+                    Ok(())
                 })?;
         }
     }

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,4 +1,4 @@
-use crate::bounds::{BoundOrFiller, BoundsType, UserBounds, UserBoundsList};
+use crate::bounds::{BoundsType, UserBoundsList};
 use anyhow::Result;
 use std::str::FromStr;
 
@@ -54,7 +54,7 @@ impl Default for Opt {
         Opt {
             delimiter: String::from("-"),
             eol: EOL::Newline,
-            bounds: UserBoundsList::new(vec![BoundOrFiller::Bound(UserBounds::default())]),
+            bounds: UserBoundsList::from_str("1:").unwrap(),
             bounds_type: BoundsType::Fields,
             only_delimited: false,
             greedy_delimiter: false,

--- a/src/options.rs
+++ b/src/options.rs
@@ -54,7 +54,7 @@ impl Default for Opt {
         Opt {
             delimiter: String::from("-"),
             eol: EOL::Newline,
-            bounds: UserBoundsList(vec![BoundOrFiller::Bound(UserBounds::default())]),
+            bounds: UserBoundsList::new(vec![BoundOrFiller::Bound(UserBounds::default())]),
             bounds_type: BoundsType::Fields,
             only_delimited: false,
             greedy_delimiter: false,


### PR DESCRIPTION
Store more data into UserBoundsList and UserBounds to exit early in some cases, or do less computation during hot paths