### PR TITLE
Perf improvements

### DIFF
--- a/src/bounds/side.rs
+++ b/src/bounds/side.rs
@@ -31,22 +31,11 @@ impl Side {
         (self.is_negative, self.value)
     }
 
-    pub fn new_inf_left() -> Self {
-        Self {
-            value: Self::min_left(),
-            is_negative: false,
-        }
-    }
-
     pub fn new_inf_right() -> Self {
         Self {
             value: Self::max_right(),
             is_negative: false,
         }
-    }
-
-    pub const fn min_left() -> usize {
-        0
     }
 
     pub const fn max_right() -> usize {
@@ -90,11 +79,7 @@ impl Side {
     fn from_str(s: &str, is_left_bound: bool) -> Result<Self, anyhow::Error> {
         Ok(match s {
             "" => Side {
-                value: if is_left_bound {
-                    Self::min_left()
-                } else {
-                    Self::max_right()
-                },
+                value: if is_left_bound { 0 } else { Self::max_right() },
                 is_negative: false,
             },
             _ => {

--- a/src/bounds/side.rs
+++ b/src/bounds/side.rs
@@ -55,10 +55,6 @@ impl Side {
         self.value
     }
 
-    pub fn abs_value_unchecked(&self) -> usize {
-        self.value
-    }
-
     #[must_use]
     pub fn value(&self) -> (bool, usize) {
         (self.is_negative, self.value)

--- a/src/bounds/side.rs
+++ b/src/bounds/side.rs
@@ -51,7 +51,7 @@ impl Side {
         }
     }
 
-    pub fn abs_value(&self) -> usize {
+    pub fn value_unchecked(&self) -> usize {
         self.value
     }
 

--- a/src/bounds/side.rs
+++ b/src/bounds/side.rs
@@ -23,9 +23,9 @@ impl Side {
      * value as-is. The value must be 0-indexed.
      */
     #[inline(always)]
-    pub fn with_pos_value(value0idx: usize) -> Self {
+    pub fn with_pos_value(value: usize) -> Self {
         Self {
-            value: value0idx,
+            value,
             is_negative: false,
         }
     }
@@ -35,9 +35,9 @@ impl Side {
      * value as-is. The value must be 0-indexed.
      */
     #[inline(always)]
-    pub fn with_neg_value(value0idx: usize) -> Self {
+    pub fn with_neg_value(value: usize) -> Self {
         Self {
-            value: value0idx,
+            value,
             is_negative: true,
         }
     }

--- a/src/bounds/side.rs
+++ b/src/bounds/side.rs
@@ -22,6 +22,7 @@ impl Side {
      * Create a new Side, using the provided
      * value as-is. The value must be 0-indexed.
      */
+    #[inline(always)]
     pub fn with_pos_value(value0idx: usize) -> Self {
         Self {
             value: value0idx,
@@ -33,6 +34,7 @@ impl Side {
      * Create a new Side, using the provided
      * value as-is. The value must be 0-indexed.
      */
+    #[inline(always)]
     pub fn with_neg_value(value0idx: usize) -> Self {
         Self {
             value: value0idx,
@@ -44,6 +46,7 @@ impl Side {
      * Create a new Side, positive, with
      * value set to Self::max_right()
      */
+    #[inline(always)]
     pub fn with_pos_inf() -> Self {
         Self {
             value: Self::max_right(),
@@ -51,19 +54,23 @@ impl Side {
         }
     }
 
+    #[inline(always)]
     pub fn value_unchecked(&self) -> usize {
         self.value
     }
 
+    #[inline(always)]
     #[must_use]
     pub fn value(&self) -> (bool, usize) {
         (self.is_negative, self.value)
     }
 
+    #[inline(always)]
     pub const fn max_right() -> usize {
         usize::MAX
     }
 
+    #[inline(always)]
     pub fn is_negative(&self) -> bool {
         self.is_negative
     }
@@ -108,6 +115,7 @@ impl Side {
 }
 
 impl PartialOrd for Side {
+    #[inline(always)]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         if self.is_negative ^ other.is_negative {
             // We can't compare two sides with different sign

--- a/src/bounds/side.rs
+++ b/src/bounds/side.rs
@@ -17,22 +17,6 @@ impl std::fmt::Display for Side {
     }
 }
 
-impl From<i32> for Side {
-    fn from(value: i32) -> Self {
-        if value >= 0 {
-            Side {
-                value: usize::try_from(value).unwrap() - 1,
-                is_negative: false,
-            }
-        } else {
-            Side {
-                value: usize::try_from(value.abs()).unwrap() - 1,
-                is_negative: true,
-            }
-        }
-    }
-}
-
 impl Side {
     pub fn abs_value(&self) -> usize {
         self.value
@@ -89,6 +73,17 @@ impl Side {
         Self {
             value: value0idx,
             is_negative: false,
+        }
+    }
+
+    /**
+     * Create a new Side, using the provided
+     * value as-is. The value must be 0-indexed.
+     */
+    pub fn with_neg_value(value0idx: usize) -> Self {
+        Self {
+            value: value0idx,
+            is_negative: true,
         }
     }
 
@@ -158,31 +153,6 @@ impl PartialOrd for Side {
             Some(other.value.cmp(&self.value))
         } else {
             Some(self.value.cmp(&other.value))
-        }
-    }
-}
-
-impl From<usize> for Side {
-    fn from(value: usize) -> Self {
-        Side {
-            value: value - 1,
-            is_negative: false,
-        }
-    }
-}
-
-impl From<isize> for Side {
-    fn from(value: isize) -> Self {
-        if value >= 0 {
-            Side {
-                value: usize::try_from(value).unwrap() - 1,
-                is_negative: false,
-            }
-        } else {
-            Side {
-                value: usize::try_from(value.abs()).unwrap() - 1,
-                is_negative: true,
-            }
         }
     }
 }

--- a/src/bounds/side.rs
+++ b/src/bounds/side.rs
@@ -105,26 +105,6 @@ impl Side {
             }
         })
     }
-    /**
-     * Check if a field is between the bounds.
-     *
-     * It errors out if the index has different sign than the bounds
-     * (we can't verify if e.g. -1 idx is between 3:5 without knowing the number
-     * of matching bounds).
-     */
-    #[inline(always)]
-    pub fn between(&self, other: &Self, idx: usize) -> Result<bool> {
-        if self.is_negative ^ other.is_negative {
-            // We can't compare two sides with different sign
-            bail!(
-                "sign mismatch. Can't verify if index {} is between bounds {}",
-                idx + 1,
-                self
-            )
-        }
-
-        Ok((self.value..=other.value).contains(&(idx)))
-    }
 }
 
 impl PartialOrd for Side {

--- a/src/bounds/side.rs
+++ b/src/bounds/side.rs
@@ -3,36 +3,30 @@ use std::cmp::Ordering;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Side {
-    // Pack positive and negative fields into a single u64:
-    // - bit 63: is_negative flag
-    // - bits 0-62: value (supports values up to 2^62)
-    packed: u64,
+    value: usize,
+    is_negative: bool,
 }
 
 impl std::fmt::Display for Side {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        if self.is_negative() {
-            write!(f, "-{}", self.value_unchecked() + 1)
+        if self.is_negative {
+            write!(f, "-{}", self.value + 1)
         } else {
-            write!(f, "{}", self.value_unchecked() + 1)
+            write!(f, "{}", self.value + 1)
         }
     }
 }
 
 impl Side {
-    const NEGATIVE_FLAG: u64 = 1u64 << 63;
-    const VALUE_MASK: u64 = !Self::NEGATIVE_FLAG;
-    const MAX_VALUE: usize = (Self::VALUE_MASK) as usize; // 2^63 - 1
-
     /**
      * Create a new Side, using the provided
      * value as-is. The value must be 0-indexed.
      */
     #[inline(always)]
-    pub fn with_pos_value(value: usize) -> Self {
-        debug_assert!(value <= (Self::MAX_VALUE), "Value too large");
+    pub fn with_pos_value(value0idx: usize) -> Self {
         Self {
-            packed: (value as u64),
+            value: value0idx,
+            is_negative: false,
         }
     }
 
@@ -41,10 +35,10 @@ impl Side {
      * value as-is. The value must be 0-indexed.
      */
     #[inline(always)]
-    pub fn with_neg_value(value: usize) -> Self {
-        debug_assert!(value <= (Self::MAX_VALUE), "Value too large");
+    pub fn with_neg_value(value0idx: usize) -> Self {
         Self {
-            packed: (value as u64) | Self::NEGATIVE_FLAG,
+            value: value0idx,
+            is_negative: true,
         }
     }
 
@@ -55,29 +49,30 @@ impl Side {
     #[inline(always)]
     pub fn with_pos_inf() -> Self {
         Self {
-            packed: Self::MAX_VALUE as u64,
+            value: Self::max_right(),
+            is_negative: false,
         }
     }
 
     #[inline(always)]
     pub fn value_unchecked(&self) -> usize {
-        (self.packed & Self::VALUE_MASK) as usize
+        self.value
     }
 
     #[inline(always)]
     #[must_use]
     pub fn value(&self) -> (bool, usize) {
-        (self.is_negative(), self.value_unchecked())
+        (self.is_negative, self.value)
     }
 
     #[inline(always)]
     pub const fn max_right() -> usize {
-        Self::MAX_VALUE
+        usize::MAX
     }
 
     #[inline(always)]
     pub fn is_negative(&self) -> bool {
-        self.packed & Self::NEGATIVE_FLAG != 0
+        self.is_negative
     }
 
     pub fn from_str_left_bound(s: &str) -> Result<Self, anyhow::Error> {
@@ -90,7 +85,10 @@ impl Side {
 
     fn from_str(s: &str, is_left_bound: bool) -> Result<Self, anyhow::Error> {
         Ok(match s {
-            "" => Side::with_pos_value(if is_left_bound { 0 } else { Self::max_right() }),
+            "" => Side {
+                value: if is_left_bound { 0 } else { Self::max_right() },
+                is_negative: false,
+            },
             _ => {
                 let v = s
                     .parse::<isize>()
@@ -101,9 +99,15 @@ impl Side {
                 }
 
                 if v > 0 {
-                    Side::with_pos_value(usize::try_from(v.abs()).unwrap() - 1)
+                    Side {
+                        value: usize::try_from(v.abs()).unwrap() - 1,
+                        is_negative: false,
+                    }
                 } else {
-                    Side::with_neg_value(usize::try_from(v.abs()).unwrap() - 1)
+                    Side {
+                        value: usize::try_from(v.abs()).unwrap() - 1,
+                        is_negative: true,
+                    }
                 }
             }
         })
@@ -113,15 +117,15 @@ impl Side {
 impl PartialOrd for Side {
     #[inline(always)]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        if self.is_negative() ^ other.is_negative() {
+        if self.is_negative ^ other.is_negative {
             // We can't compare two sides with different sign
             return None;
         }
 
-        if self.is_negative() {
-            Some(other.value_unchecked().cmp(&self.value_unchecked()))
+        if self.is_negative {
+            Some(other.value.cmp(&self.value))
         } else {
-            Some(self.value_unchecked().cmp(&other.value_unchecked()))
+            Some(self.value.cmp(&other.value))
         }
     }
 }
@@ -133,18 +137,36 @@ mod tests {
     #[test]
     fn test_from_str_some() {
         assert_eq!(
-            Side::from_str_left_bound("42").unwrap().value(),
-            (false, 41)
+            Side::from_str_left_bound("42").unwrap(),
+            Side {
+                value: 41,
+                is_negative: false
+            }
         );
-        assert_eq!(Side::from_str_left_bound("-7").unwrap().value(), (true, 6));
+        assert_eq!(
+            Side::from_str_left_bound("-7").unwrap(),
+            Side {
+                value: 6,
+                is_negative: true
+            }
+        );
     }
 
     #[test]
     fn test_from_str_continue() {
-        assert_eq!(Side::from_str_left_bound("").unwrap().value(), (false, 0));
         assert_eq!(
-            Side::from_str_right_bound("").unwrap().value(),
-            (false, Side::max_right())
+            Side::from_str_left_bound("").unwrap(),
+            Side {
+                value: 0,
+                is_negative: false
+            }
+        );
+        assert_eq!(
+            Side::from_str_right_bound("").unwrap(),
+            Side {
+                value: usize::MAX,
+                is_negative: false
+            }
         );
     }
 

--- a/src/bounds/side.rs
+++ b/src/bounds/side.rs
@@ -18,42 +18,6 @@ impl std::fmt::Display for Side {
 }
 
 impl Side {
-    pub fn abs_value(&self) -> usize {
-        self.value
-    }
-
-    pub fn abs_value_unchecked(&self) -> usize {
-        self.value
-    }
-
-    #[must_use]
-    pub fn value(&self) -> (bool, usize) {
-        (self.is_negative, self.value)
-    }
-
-    pub fn new_inf_right() -> Self {
-        Self {
-            value: Self::max_right(),
-            is_negative: false,
-        }
-    }
-
-    pub const fn max_right() -> usize {
-        usize::MAX
-    }
-
-    pub fn is_negative(&self) -> bool {
-        self.is_negative
-    }
-
-    pub fn from_str_left_bound(s: &str) -> Result<Self, anyhow::Error> {
-        Self::from_str(s, true)
-    }
-
-    pub fn from_str_right_bound(s: &str) -> Result<Self, anyhow::Error> {
-        Self::from_str(s, false)
-    }
-
     /**
      * Create a new Side, using the provided
      * value as-is. The value must be 0-indexed.
@@ -74,6 +38,46 @@ impl Side {
             value: value0idx,
             is_negative: true,
         }
+    }
+
+    /**
+     * Create a new Side, positive, with
+     * value set to Self::max_right()
+     */
+    pub fn with_pos_inf() -> Self {
+        Self {
+            value: Self::max_right(),
+            is_negative: false,
+        }
+    }
+
+    pub fn abs_value(&self) -> usize {
+        self.value
+    }
+
+    pub fn abs_value_unchecked(&self) -> usize {
+        self.value
+    }
+
+    #[must_use]
+    pub fn value(&self) -> (bool, usize) {
+        (self.is_negative, self.value)
+    }
+
+    pub const fn max_right() -> usize {
+        usize::MAX
+    }
+
+    pub fn is_negative(&self) -> bool {
+        self.is_negative
+    }
+
+    pub fn from_str_left_bound(s: &str) -> Result<Self, anyhow::Error> {
+        Self::from_str(s, true)
+    }
+
+    pub fn from_str_right_bound(s: &str) -> Result<Self, anyhow::Error> {
+        Self::from_str(s, false)
     }
 
     fn from_str(s: &str, is_left_bound: bool) -> Result<Self, anyhow::Error> {

--- a/src/bounds/side.rs
+++ b/src/bounds/side.rs
@@ -1,50 +1,175 @@
 use anyhow::{Result, bail};
 use std::cmp::Ordering;
-use std::fmt;
-use std::str::FromStr;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Side {
-    Some(i32),
-    Continue,
+pub struct Side {
+    value: usize,
+    is_negative: bool,
 }
 
-impl FromStr for Side {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(match s {
-            "" => Side::Continue,
-            _ => Side::Some(
-                s.parse::<i32>()
-                    .or_else(|_| bail!("Not a number `{}`", s))?,
-            ),
-        })
+impl std::fmt::Display for Side {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        if self.is_negative {
+            write!(f, "-{}", self.value)
+        } else {
+            write!(f, "{}", self.value)
+        }
     }
 }
 
-impl fmt::Display for Side {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Side::Some(v) => write!(f, "{v}"),
-            Side::Continue => write!(f, ""),
+impl From<i32> for Side {
+    fn from(value: i32) -> Self {
+        if value >= 0 {
+            Side {
+                value: usize::try_from(value).unwrap(),
+                is_negative: false,
+            }
+        } else {
+            Side {
+                value: usize::try_from(value.abs()).unwrap(),
+                is_negative: true,
+            }
         }
+    }
+}
+
+impl Side {
+    pub fn abs_value(&self) -> usize {
+        self.value
+    }
+
+    pub fn abs_value_unchecked(&self) -> usize {
+        self.value
+    }
+
+    #[must_use]
+    pub fn value(&self) -> (bool, usize) {
+        (self.is_negative, self.value)
+    }
+
+    pub fn new_inf_left() -> Self {
+        Self {
+            value: Self::min_left(),
+            is_negative: false,
+        }
+    }
+
+    pub fn new_inf_right() -> Self {
+        Self {
+            value: Self::max_right(),
+            is_negative: false,
+        }
+    }
+
+    pub const fn min_left() -> usize {
+        1
+    }
+
+    pub const fn max_right() -> usize {
+        usize::MAX
+    }
+
+    pub fn is_negative(&self) -> bool {
+        self.is_negative
+    }
+
+    pub fn from_str_left_bound(s: &str) -> Result<Self, anyhow::Error> {
+        Self::from_str(s, true)
+    }
+
+    pub fn from_str_right_bound(s: &str) -> Result<Self, anyhow::Error> {
+        Self::from_str(s, false)
+    }
+
+    fn from_str(s: &str, is_left_bound: bool) -> Result<Self, anyhow::Error> {
+        Ok(match s {
+            "" => Side {
+                value: if is_left_bound {
+                    Self::min_left()
+                } else {
+                    Self::max_right()
+                },
+                is_negative: false,
+            },
+            _ => {
+                let v = s
+                    .parse::<isize>()
+                    .or_else(|_| bail!("Not a number `{}`", s))?;
+
+                if v >= 0 {
+                    Side {
+                        value: usize::try_from(v.abs()).unwrap(),
+                        is_negative: false,
+                    }
+                } else {
+                    Side {
+                        value: usize::try_from(v.abs()).unwrap(),
+                        is_negative: true,
+                    }
+                }
+            }
+        })
+    }
+    /**
+     * Check if a field is between the bounds.
+     *
+     * It errors out if the index has different sign than the bounds
+     * (we can't verify if e.g. -1 idx is between 3:5 without knowing the number
+     * of matching bounds).
+     *
+     * Fields are 1-indexed.
+     */
+    #[inline(always)]
+    pub fn between(&self, other: &Self, idx: usize) -> Result<bool> {
+        if self.is_negative ^ other.is_negative {
+            // We can't compare two sides with different sign
+            bail!(
+                "sign mismatch. Can't verify if index {} is between bounds {}",
+                idx,
+                self
+            )
+        }
+
+        Ok((self.value..=other.value).contains(&idx))
     }
 }
 
 impl PartialOrd for Side {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        match (self, other) {
-            (Side::Some(s), Side::Some(o)) => {
-                if s.is_negative() ^ o.is_negative() {
-                    // We can't compare two sides with different sign
-                    return None;
-                }
-                Some(s.cmp(o))
+        if self.is_negative ^ other.is_negative {
+            // We can't compare two sides with different sign
+            return None;
+        }
+
+        if self.is_negative {
+            Some(other.value.cmp(&self.value))
+        } else {
+            Some(self.value.cmp(&other.value))
+        }
+    }
+}
+
+impl From<usize> for Side {
+    fn from(value: usize) -> Self {
+        Side {
+            value,
+            is_negative: false,
+        }
+    }
+}
+
+impl From<isize> for Side {
+    fn from(value: isize) -> Self {
+        if value >= 0 {
+            Side {
+                value: usize::try_from(value).unwrap(),
+                is_negative: false,
             }
-            (Side::Continue, Side::Some(_)) => Some(Ordering::Greater),
-            (Side::Some(_), Side::Continue) => Some(Ordering::Less),
-            (Side::Continue, Side::Continue) => Some(Ordering::Equal),
+        } else {
+            Side {
+                value: usize::try_from(value.abs()).unwrap(),
+                is_negative: true,
+            }
         }
     }
 }
@@ -55,65 +180,98 @@ mod tests {
 
     #[test]
     fn test_from_str_some() {
-        assert_eq!(Side::from_str("42").unwrap(), Side::Some(42));
-        assert_eq!(Side::from_str("-7").unwrap(), Side::Some(-7));
+        assert_eq!(
+            Side::from_str_left_bound("42").unwrap(),
+            Side {
+                value: 42,
+                is_negative: false
+            }
+        );
+        assert_eq!(
+            Side::from_str_left_bound("-7").unwrap(),
+            Side {
+                value: 7,
+                is_negative: true
+            }
+        );
     }
 
     #[test]
     fn test_from_str_continue() {
-        assert_eq!(Side::from_str("").unwrap(), Side::Continue);
+        assert_eq!(
+            Side::from_str_left_bound("").unwrap(),
+            Side {
+                value: 1,
+                is_negative: false
+            }
+        );
+        assert_eq!(
+            Side::from_str_right_bound("").unwrap(),
+            Side {
+                value: usize::MAX,
+                is_negative: false
+            }
+        );
     }
 
     #[test]
     fn test_from_str_zero() {
-        assert_eq!(Side::from_str("0").unwrap(), Side::Some(0));
+        assert_eq!(
+            Side::from_str_left_bound("0").unwrap(),
+            Side {
+                value: 0,
+                is_negative: false
+            }
+        );
     }
 
     #[test]
     fn test_from_str_invalid() {
-        assert!(Side::from_str("abc").is_err());
-        assert!(Side::from_str("4.2").is_err());
+        assert!(Side::from_str_left_bound("abc").is_err());
+        assert!(Side::from_str_left_bound("4.2").is_err());
     }
 
     #[test]
     fn test_partial_ord_same_sign() {
         assert_eq!(
-            Side::Some(3).partial_cmp(&Side::Some(5)),
+            Side::from_str_left_bound("3")
+                .unwrap()
+                .partial_cmp(&Side::from_str_left_bound("5").unwrap()),
             Some(Ordering::Less)
         );
         assert_eq!(
-            Side::Some(5).partial_cmp(&Side::Some(3)),
+            Side::from_str_left_bound("5")
+                .unwrap()
+                .partial_cmp(&Side::from_str_left_bound("3").unwrap()),
             Some(Ordering::Greater)
         );
         assert_eq!(
-            Side::Some(7).partial_cmp(&Side::Some(7)),
+            Side::from_str_left_bound("7")
+                .unwrap()
+                .partial_cmp(&Side::from_str_left_bound("7").unwrap()),
             Some(Ordering::Equal)
         );
         assert_eq!(
-            Side::Some(-2).partial_cmp(&Side::Some(-1)),
+            Side::from_str_left_bound("-2")
+                .unwrap()
+                .partial_cmp(&Side::from_str_left_bound("-1").unwrap()),
             Some(Ordering::Less)
         );
     }
 
     #[test]
     fn test_partial_ord_different_sign() {
-        assert_eq!(Side::Some(3).partial_cmp(&Side::Some(-5)), None);
-        assert_eq!(Side::Some(-5).partial_cmp(&Side::Some(3)), None);
-    }
-
-    #[test]
-    fn test_partial_ord_continue() {
         assert_eq!(
-            Side::Continue.partial_cmp(&Side::Some(1)),
-            Some(Ordering::Greater)
+            Side::from_str_left_bound("3")
+                .unwrap()
+                .partial_cmp(&Side::from_str_left_bound("-5").unwrap()),
+            None
         );
         assert_eq!(
-            Side::Some(1).partial_cmp(&Side::Continue),
-            Some(Ordering::Less)
-        );
-        assert_eq!(
-            Side::Continue.partial_cmp(&Side::Continue),
-            Some(Ordering::Equal)
+            Side::from_str_left_bound("-5")
+                .unwrap()
+                .partial_cmp(&Side::from_str_left_bound("3").unwrap()),
+            None
         );
     }
 
@@ -121,29 +279,59 @@ mod tests {
     fn test_partial_ord_zero() {
         // Zero compared to positive
         assert_eq!(
-            Side::Some(0).partial_cmp(&Side::Some(5)),
+            Side::from_str_left_bound("")
+                .unwrap()
+                .partial_cmp(&Side::from_str_left_bound("5").unwrap()),
             Some(Ordering::Less)
         );
         assert_eq!(
-            Side::Some(5).partial_cmp(&Side::Some(0)),
+            Side::from_str_left_bound("5")
+                .unwrap()
+                .partial_cmp(&Side::from_str_left_bound("0").unwrap()),
             Some(Ordering::Greater)
         );
         assert_eq!(
-            Side::Some(0).partial_cmp(&Side::Some(0)),
+            Side::from_str_left_bound("0")
+                .unwrap()
+                .partial_cmp(&Side::from_str_left_bound("0").unwrap()),
             Some(Ordering::Equal)
         );
 
         // Zero compared to negative
-        assert_eq!(Side::Some(0).partial_cmp(&Side::Some(-5)), None);
-        assert_eq!(Side::Some(-5).partial_cmp(&Side::Some(0)), None);
+        assert_eq!(
+            Side::from_str_left_bound("0")
+                .unwrap()
+                .partial_cmp(&Side::from_str_left_bound("-5").unwrap()),
+            None
+        );
+        assert_eq!(
+            Side::from_str_left_bound("-5")
+                .unwrap()
+                .partial_cmp(&Side::from_str_left_bound("0").unwrap()),
+            None
+        );
     }
 
     #[test]
     fn test_eq_trait() {
-        assert_eq!(Side::Some(1), Side::Some(1));
-        assert_eq!(Side::Continue, Side::Continue);
+        assert_eq!(
+            Side::from_str_left_bound("1").unwrap(),
+            Side::from_str_left_bound("1").unwrap()
+        );
 
-        assert_ne!(Side::Some(1), Side::Some(2));
-        assert_ne!(Side::Continue, Side::Some(0));
+        assert_eq!(
+            Side::from_str_left_bound("-1").unwrap(),
+            Side::from_str_left_bound("-1").unwrap()
+        );
+
+        assert_ne!(
+            Side::from_str_left_bound("1").unwrap(),
+            Side::from_str_left_bound("2").unwrap()
+        );
+
+        assert_ne!(
+            Side::from_str_left_bound("-1").unwrap(),
+            Side::from_str_left_bound("1").unwrap()
+        );
     }
 }

--- a/src/bounds/userbounds.rs
+++ b/src/bounds/userbounds.rs
@@ -88,7 +88,7 @@ impl FromStr for UserBounds {
                 (side, side)
             }
             Some(idx_colon) if idx_colon == 0 => (
-                Side::new_inf_left(),
+                Side::with_pos_value(0),
                 Side::from_str_right_bound(&s[idx_colon + 1..])?,
             ),
             Some(idx_colon) if idx_colon == s.len() - 1 => (
@@ -135,7 +135,7 @@ impl PartialEq for UserBounds {
 
 impl Default for UserBounds {
     fn default() -> Self {
-        UserBounds::new(Side::new_inf_left(), Side::new_inf_right())
+        UserBounds::new(Side::with_pos_value(0), Side::new_inf_right())
     }
 }
 
@@ -379,11 +379,11 @@ mod tests {
         );
         assert_eq!(
             UserBounds::from_str(":1").ok(),
-            Some(UserBounds::new(Side::new_inf_left(), side_pos(0))),
+            Some(UserBounds::new(Side::with_pos_value(0), side_pos(0))),
         );
         assert_eq!(
             UserBounds::from_str(":-1").ok(),
-            Some(UserBounds::new(Side::new_inf_left(), side_neg(0))),
+            Some(UserBounds::new(Side::with_pos_value(0), side_neg(0))),
         );
 
         assert_eq!(

--- a/src/bounds/userbounds.rs
+++ b/src/bounds/userbounds.rs
@@ -142,7 +142,7 @@ impl Default for UserBounds {
     }
 }
 
-pub trait UserBoundsTrait<T> {
+pub trait UserBoundsTrait {
     fn new(l: Side, r: Side) -> Self;
     fn with_fallback(l: Side, r: Side, fallback_oob: Option<Vec<u8>>) -> Self;
     fn try_into_range(&self, parts_length: usize) -> Result<Range<usize>>;
@@ -151,7 +151,7 @@ pub trait UserBoundsTrait<T> {
     fn complement(&self, num_fields: usize) -> Result<Vec<UserBounds>>;
 }
 
-impl UserBoundsTrait<i32> for UserBounds {
+impl UserBoundsTrait for UserBounds {
     fn new(l: Side, r: Side) -> Self {
         UserBounds {
             l,

--- a/src/bounds/userbounds.rs
+++ b/src/bounds/userbounds.rs
@@ -93,7 +93,7 @@ impl FromStr for UserBounds {
             ),
             Some(idx_colon) if idx_colon == s.len() - 1 => (
                 Side::from_str_left_bound(&s[..idx_colon])?,
-                Side::new_inf_right(),
+                Side::with_pos_inf(),
             ),
             Some(idx_colon) => (
                 Side::from_str_left_bound(&s[..idx_colon])?,
@@ -135,7 +135,7 @@ impl PartialEq for UserBounds {
 
 impl Default for UserBounds {
     fn default() -> Self {
-        UserBounds::new(Side::with_pos_value(0), Side::new_inf_right())
+        UserBounds::new(Side::with_pos_value(0), Side::with_pos_inf())
     }
 }
 
@@ -371,11 +371,11 @@ mod tests {
         );
         assert_eq!(
             UserBounds::from_str("1:").ok(),
-            Some(UserBounds::new(side_pos(0), Side::new_inf_right())),
+            Some(UserBounds::new(side_pos(0), Side::with_pos_inf())),
         );
         assert_eq!(
             UserBounds::from_str("-1:").ok(),
-            Some(UserBounds::new(side_neg(0), Side::new_inf_right())),
+            Some(UserBounds::new(side_neg(0), Side::with_pos_inf())),
         );
         assert_eq!(
             UserBounds::from_str(":1").ok(),

--- a/src/bounds/userbounds.rs
+++ b/src/bounds/userbounds.rs
@@ -125,12 +125,14 @@ impl PartialOrd for UserBounds {
     /// bounds with a mix of positive/negative indices (you cannot
     /// compare `-1` with `3` without kwowing how many parts are there).
     /// Check with UserBounds.is_sortable before comparing.
+    #[inline(always)]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         self.r.partial_cmp(&other.l)
     }
 }
 
 impl PartialEq for UserBounds {
+    #[inline(always)]
     fn eq(&self, other: &Self) -> bool {
         (self.l, self.r) == (other.l, other.r)
     }

--- a/src/bounds/userbounds.rs
+++ b/src/bounds/userbounds.rs
@@ -179,7 +179,19 @@ impl UserBoundsTrait<i32> for UserBounds {
      */
     #[inline(always)]
     fn matches(&self, idx: usize) -> Result<bool> {
-        self.l.between(&self.r, idx)
+        let (l_is_negative, l_value) = self.l.value();
+        let (r_is_negative, r_value) = self.r.value();
+
+        if l_is_negative ^ r_is_negative {
+            // We can't compare two sides with different sign
+            bail!(
+                "sign mismatch. Can't verify if index {} is between bounds {}",
+                idx + 1,
+                self
+            )
+        }
+
+        Ok((l_value..=r_value).contains(&(idx)))
     }
 
     /// Transform UserBounds into std::opt::Range

--- a/src/bounds/userbounds.rs
+++ b/src/bounds/userbounds.rs
@@ -9,10 +9,46 @@ use crate::bounds::Side;
 
 #[derive(Debug, Eq, Clone)]
 pub struct UserBounds {
-    pub l: Side,
-    pub r: Side,
-    pub is_last: bool,
-    pub fallback_oob: Option<Vec<u8>>,
+    l: Side,
+    r: Side,
+    is_last: bool,
+    fallback_oob: Option<Vec<u8>>,
+}
+
+impl UserBounds {
+    pub fn new(l: Side, r: Side) -> Self {
+        Self {
+            l,
+            r,
+            is_last: false,
+            fallback_oob: None,
+        }
+    }
+
+    #[inline(always)]
+    pub fn l(&self) -> &Side {
+        &self.l
+    }
+
+    #[inline(always)]
+    pub fn r(&self) -> &Side {
+        &self.r
+    }
+
+    #[inline(always)]
+    pub fn is_last(&self) -> bool {
+        self.is_last
+    }
+
+    #[inline(always)]
+    pub fn set_is_last(&mut self, is_last: bool) {
+        self.is_last = is_last;
+    }
+
+    #[inline(always)]
+    pub fn fallback_oob(&self) -> &Option<Vec<u8>> {
+        &self.fallback_oob
+    }
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/src/bounds/userboundslist.rs
+++ b/src/bounds/userboundslist.rs
@@ -34,8 +34,8 @@ impl From<Vec<BoundOrFiller>> for UserBoundsList {
 
         ubl.list.iter_mut().for_each(|bof| {
             if let BoundOrFiller::Bound(b) = bof {
-                if rightmost_bound.is_none() || b.r > rightmost_bound.unwrap() {
-                    rightmost_bound = Some(b.r);
+                if rightmost_bound.is_none() || *b.r() > rightmost_bound.unwrap() {
+                    rightmost_bound = Some(*b.r());
                 }
 
                 last_bound = Some(b);
@@ -48,7 +48,7 @@ impl From<Vec<BoundOrFiller>> for UserBoundsList {
 
         last_bound
             .expect("UserBoundsList must contain at least one UserBounds")
-            .is_last = true;
+            .set_is_last(true);
 
         ubl.last_interesting_field = rightmost_bound.unwrap_or(Side::Continue);
         ubl
@@ -73,7 +73,7 @@ impl UserBoundsList {
         let mut has_positive_idx = false;
         let mut has_negative_idx = false;
         self.get_userbounds_only().for_each(|b| {
-            if let Side::Some(left) = b.l {
+            if let Side::Some(left) = b.l() {
                 if left.is_positive() {
                     has_positive_idx = true;
                 } else {
@@ -81,7 +81,7 @@ impl UserBoundsList {
                 }
             }
 
-            if let Side::Some(right) = b.r {
+            if let Side::Some(right) = b.r() {
                 if right.is_positive() {
                     has_positive_idx = true;
                 } else {
@@ -115,11 +115,11 @@ impl UserBoundsList {
 
     fn has_negative_indices(&self) -> bool {
         self.get_userbounds_only().any(|b| {
-            if let Side::Some(left) = b.l
+            if let Side::Some(left) = b.l()
                 && left.is_negative()
             {
                 true
-            } else if let Side::Some(right) = b.r
+            } else if let Side::Some(right) = b.r()
                 && right.is_negative()
             {
                 true

--- a/src/bounds/userboundslist.rs
+++ b/src/bounds/userboundslist.rs
@@ -24,7 +24,7 @@ impl From<Vec<BoundOrFiller>> for UserBoundsList {
     fn from(list: Vec<BoundOrFiller>) -> Self {
         let mut ubl = UserBoundsList {
             list,
-            last_interesting_field: Side::new_inf_right(),
+            last_interesting_field: Side::with_pos_inf(),
         };
 
         let mut rightmost_bound: Option<Side> = None;
@@ -52,7 +52,7 @@ impl From<Vec<BoundOrFiller>> for UserBoundsList {
 
         ubl.last_interesting_field = rightmost_bound
             .and_then(|x| if x.is_negative() { None } else { Some(x) })
-            .unwrap_or(Side::new_inf_right());
+            .unwrap_or(Side::with_pos_inf());
         ubl
     }
 }

--- a/src/bounds/userboundslist.rs
+++ b/src/bounds/userboundslist.rs
@@ -266,6 +266,14 @@ pub fn parse_bounds_list(s: &str) -> Result<Vec<BoundOrFiller>> {
 mod tests {
     use super::*;
 
+    fn side_pos(l: usize) -> Side {
+        Side::with_pos_value(l)
+    }
+
+    fn side_neg(l: usize) -> Side {
+        Side::with_neg_value(l)
+    }
+
     #[test]
     fn test_parse_bounds_list() {
         // do not replicate tests from test_user_bounds_from_str, focus on
@@ -305,7 +313,10 @@ mod tests {
 
         assert_eq!(
             parse_bounds_list("1").unwrap(),
-            vec![BoundOrFiller::Bound(UserBounds::new(1.into(), 1.into()))],
+            vec![BoundOrFiller::Bound(UserBounds::new(
+                side_pos(0),
+                side_pos(0)
+            ))],
         );
 
         assert_eq!(
@@ -316,34 +327,40 @@ mod tests {
         assert_eq!(
             parse_bounds_list("1,2").unwrap(),
             vec![
-                BoundOrFiller::Bound(UserBounds::new(1.into(), 1.into())),
-                BoundOrFiller::Bound(UserBounds::new(2.into(), 2.into())),
+                BoundOrFiller::Bound(UserBounds::new(side_pos(0), side_pos(0))),
+                BoundOrFiller::Bound(UserBounds::new(side_pos(1), side_pos(1))),
             ],
         );
 
         assert_eq!(
             parse_bounds_list("-1,1").unwrap(),
             vec![
-                BoundOrFiller::Bound(UserBounds::new((-1).into(), (-1).into())),
-                BoundOrFiller::Bound(UserBounds::new(1.into(), 1.into())),
+                BoundOrFiller::Bound(UserBounds::new(side_neg(0), side_neg(0))),
+                BoundOrFiller::Bound(UserBounds::new(side_pos(0), side_pos(0))),
             ],
         );
 
         assert_eq!(
             parse_bounds_list("{1}").unwrap(),
-            vec![BoundOrFiller::Bound(UserBounds::new(1.into(), 1.into()))],
+            vec![BoundOrFiller::Bound(UserBounds::new(
+                side_pos(0),
+                side_pos(0)
+            ))],
         );
 
         assert_eq!(
             parse_bounds_list("{1:2}").unwrap(),
-            vec![BoundOrFiller::Bound(UserBounds::new(1.into(), 2.into()))],
+            vec![BoundOrFiller::Bound(UserBounds::new(
+                side_pos(0),
+                side_pos(1)
+            ))],
         );
 
         assert_eq!(
             parse_bounds_list("{1,2}").unwrap(),
             vec![
-                BoundOrFiller::Bound(UserBounds::new(1.into(), 1.into())),
-                BoundOrFiller::Bound(UserBounds::new(2.into(), 2.into()))
+                BoundOrFiller::Bound(UserBounds::new(side_pos(0), side_pos(0))),
+                BoundOrFiller::Bound(UserBounds::new(side_pos(1), side_pos(1)))
             ],
         );
 
@@ -351,8 +368,8 @@ mod tests {
             parse_bounds_list("hello {1,2} {{world}}").unwrap(),
             vec![
                 BoundOrFiller::Filler("hello ".into()),
-                BoundOrFiller::Bound(UserBounds::new(1.into(), 1.into())),
-                BoundOrFiller::Bound(UserBounds::new(2.into(), 2.into())),
+                BoundOrFiller::Bound(UserBounds::new(side_pos(0), side_pos(0))),
+                BoundOrFiller::Bound(UserBounds::new(side_pos(1), side_pos(1))),
                 BoundOrFiller::Filler(" {world}".into()),
             ],
         );
@@ -360,9 +377,9 @@ mod tests {
         assert_eq!(
             parse_bounds_list("{1}😎{2}").unwrap(),
             vec![
-                BoundOrFiller::Bound(UserBounds::new(1.into(), 1.into())),
+                BoundOrFiller::Bound(UserBounds::new(side_pos(0), side_pos(0))),
                 BoundOrFiller::Filler("😎".into()),
-                BoundOrFiller::Bound(UserBounds::new(2.into(), 2.into()))
+                BoundOrFiller::Bound(UserBounds::new(side_pos(1), side_pos(1)))
             ],
         );
 
@@ -370,8 +387,8 @@ mod tests {
             parse_bounds_list("\\n\\t{{}}{1,2}\\n\\t{{}}").unwrap(),
             vec![
                 BoundOrFiller::Filler("\n\t{}".into()),
-                BoundOrFiller::Bound(UserBounds::new(1.into(), 1.into())),
-                BoundOrFiller::Bound(UserBounds::new(2.into(), 2.into())),
+                BoundOrFiller::Bound(UserBounds::new(side_pos(0), side_pos(0))),
+                BoundOrFiller::Bound(UserBounds::new(side_pos(1), side_pos(1))),
                 BoundOrFiller::Filler("\n\t{}".into()),
             ],
         );
@@ -437,11 +454,11 @@ mod tests {
                 .unpack(4)
                 .list,
             vec![
-                BoundOrFiller::Bound(UserBounds::new(1.into(), 1.into())),
-                BoundOrFiller::Bound(UserBounds::new(1.into(), 1.into())),
-                BoundOrFiller::Bound(UserBounds::new(2.into(), 2.into())),
-                BoundOrFiller::Bound(UserBounds::new(3.into(), 3.into())),
-                BoundOrFiller::Bound(UserBounds::new(4.into(), 4.into())),
+                BoundOrFiller::Bound(UserBounds::new(side_pos(0), side_pos(0))),
+                BoundOrFiller::Bound(UserBounds::new(side_pos(0), side_pos(0))),
+                BoundOrFiller::Bound(UserBounds::new(side_pos(1), side_pos(1))),
+                BoundOrFiller::Bound(UserBounds::new(side_pos(2), side_pos(2))),
+                BoundOrFiller::Bound(UserBounds::new(side_pos(3), side_pos(3))),
             ]
         );
 
@@ -449,8 +466,8 @@ mod tests {
             UserBoundsList::from_str("a{1:2}b").unwrap().unpack(4).list,
             vec![
                 BoundOrFiller::Filler("a".into()),
-                BoundOrFiller::Bound(UserBounds::new(1.into(), 1.into())),
-                BoundOrFiller::Bound(UserBounds::new(2.into(), 2.into())),
+                BoundOrFiller::Bound(UserBounds::new(side_pos(0), side_pos(0))),
+                BoundOrFiller::Bound(UserBounds::new(side_pos(1), side_pos(1))),
                 BoundOrFiller::Filler("b".into()),
             ]
         );
@@ -465,13 +482,13 @@ mod tests {
                 .unwrap()
                 .list,
             vec![
-                BoundOrFiller::Bound(UserBounds::new(3.into(), 6.into())),
-                BoundOrFiller::Bound(UserBounds::new(1.into(), 1.into())),
-                BoundOrFiller::Bound(UserBounds::new(4.into(), 6.into())),
-                BoundOrFiller::Bound(UserBounds::new(1.into(), 4.into())),
-                BoundOrFiller::Bound(UserBounds::new(6.into(), 6.into())),
-                BoundOrFiller::Bound(UserBounds::new(1.into(), 4.into())),
-                BoundOrFiller::Bound(UserBounds::new(6.into(), 6.into())),
+                BoundOrFiller::Bound(UserBounds::new(side_pos(2), side_pos(5))),
+                BoundOrFiller::Bound(UserBounds::new(side_pos(0), side_pos(0))),
+                BoundOrFiller::Bound(UserBounds::new(side_pos(3), side_pos(5))),
+                BoundOrFiller::Bound(UserBounds::new(side_pos(0), side_pos(3))),
+                BoundOrFiller::Bound(UserBounds::new(side_pos(5), side_pos(5))),
+                BoundOrFiller::Bound(UserBounds::new(side_pos(0), side_pos(3))),
+                BoundOrFiller::Bound(UserBounds::new(side_pos(5), side_pos(5))),
             ]
         );
 

--- a/src/bounds/userboundslist.rs
+++ b/src/bounds/userboundslist.rs
@@ -50,7 +50,9 @@ impl From<Vec<BoundOrFiller>> for UserBoundsList {
             .expect("UserBoundsList must contain at least one UserBounds")
             .set_is_last(true);
 
-        ubl.last_interesting_field = rightmost_bound.unwrap_or(Side::new_inf_right());
+        ubl.last_interesting_field = rightmost_bound
+            .and_then(|x| if x.is_negative() { None } else { Some(x) })
+            .unwrap_or(Side::new_inf_right());
         ubl
     }
 }

--- a/src/cut_lines.rs
+++ b/src/cut_lines.rs
@@ -12,11 +12,11 @@ fn cut_lines_forward_only<A: BufRead, B: Write>(
     opt: &Opt,
 ) -> Result<()> {
     let mut line_buf = String::with_capacity(1024);
-    let mut line_idx = 0;
+    let mut line_idx = usize::MAX;
     let mut bounds_idx = 0; // keep track of which bounds have been used
     let mut add_newline_next = false;
     while let Some(line) = read_line_with_eol(stdin, &mut line_buf, opt.eol) {
-        line_idx += 1;
+        line_idx = line_idx.wrapping_add(1); // use wrapping add so we can start at 0
 
         let line = line?;
         let line: &str = line.as_ref();

--- a/src/cut_lines.rs
+++ b/src/cut_lines.rs
@@ -50,7 +50,8 @@ fn cut_lines_forward_only<A: BufRead, B: Write>(
                 stdout.write_all(line.as_bytes())?;
                 add_newline_next = true;
 
-                if *b.r() == Side::Some(line_idx) {
+                //tbd check neg
+                if b.r().abs_value() == line_idx {
                     // we exhausted the use of that bound, move on
                     bounds_idx += 1;
                     add_newline_next = false;
@@ -75,7 +76,8 @@ fn cut_lines_forward_only<A: BufRead, B: Write>(
 
     // Output is finished. Did we output every bound?
     if let Some(BoundOrFiller::Bound(b)) = opt.bounds.get(bounds_idx)
-        && *b.r() != Side::Continue
+    // we can ignore the sign because this is forward only
+        && b.r().abs_value() != Side::max_right()
     {
         // not good, we still have bounds to print but the input is exhausted
         bail!("Out of bounds: {}", b);

--- a/src/cut_lines.rs
+++ b/src/cut_lines.rs
@@ -50,7 +50,7 @@ fn cut_lines_forward_only<A: BufRead, B: Write>(
                 stdout.write_all(line.as_bytes())?;
                 add_newline_next = true;
 
-                if b.r == Side::Some(line_idx) {
+                if *b.r() == Side::Some(line_idx) {
                     // we exhausted the use of that bound, move on
                     bounds_idx += 1;
                     add_newline_next = false;
@@ -75,7 +75,7 @@ fn cut_lines_forward_only<A: BufRead, B: Write>(
 
     // Output is finished. Did we output every bound?
     if let Some(BoundOrFiller::Bound(b)) = opt.bounds.get(bounds_idx)
-        && b.r != Side::Continue
+        && *b.r() != Side::Continue
     {
         // not good, we still have bounds to print but the input is exhausted
         bail!("Out of bounds: {}", b);

--- a/src/cut_lines.rs
+++ b/src/cut_lines.rs
@@ -50,8 +50,7 @@ fn cut_lines_forward_only<A: BufRead, B: Write>(
                 stdout.write_all(line.as_bytes())?;
                 add_newline_next = true;
 
-                //tbd check neg
-                if b.r().abs_value() == line_idx {
+                if b.r().value_unchecked() == line_idx {
                     // we exhausted the use of that bound, move on
                     bounds_idx += 1;
                     add_newline_next = false;
@@ -77,7 +76,7 @@ fn cut_lines_forward_only<A: BufRead, B: Write>(
     // Output is finished. Did we output every bound?
     if let Some(BoundOrFiller::Bound(b)) = opt.bounds.get(bounds_idx)
     // we can ignore the sign because this is forward only
-        && b.r().abs_value() != Side::max_right()
+        && b.r().value_unchecked() != Side::max_right()
     {
         // not good, we still have bounds to print but the input is exhausted
         bail!("Out of bounds: {}", b);

--- a/src/cut_str.rs
+++ b/src/cut_str.rs
@@ -353,13 +353,12 @@ where
 {
     match (opt.read_to_end, opt.eol) {
         (false, EOL::Newline) => stdin.for_byte_line(|line| {
-            let line = line.strip_suffix(&[opt.eol as u8]).unwrap_or(line);
             cut_str(
                 line,
                 opt,
                 stdout,
                 compressed_line_buf,
-                &[opt.eol as u8],
+                &[opt.eol.into()],
                 plan,
             )
             .map_err(|x| {
@@ -369,13 +368,12 @@ where
             .and(Ok(true))
         })?,
         (false, EOL::Zero) => stdin.for_byte_record(opt.eol.into(), |line| {
-            let line = line.strip_suffix(&[opt.eol as u8]).unwrap_or(line);
             cut_str(
                 line,
                 opt,
                 stdout,
                 compressed_line_buf,
-                &[opt.eol as u8],
+                &[opt.eol.into()],
                 plan,
             )
             .map_err(|x| {

--- a/src/cut_str.rs
+++ b/src/cut_str.rs
@@ -245,9 +245,7 @@ where
 
         let field = plan.get_field(b, line.len());
         let output = if let Ok(field) = field {
-            let idx_start = field.start;
-            let idx_end = field.end;
-            &line[idx_start..idx_end]
+            &line[field.start..field.end]
         } else if b.fallback_oob.is_some() {
             b.fallback_oob.as_ref().unwrap()
         } else if let Some(generic_fallback) = &opt.fallback_oob {

--- a/src/cut_str.rs
+++ b/src/cut_str.rs
@@ -3,7 +3,7 @@ use bstr::ByteSlice;
 use bstr::io::BufReadExt;
 use std::io::{BufRead, Write};
 
-use crate::bounds::{BoundOrFiller, BoundsType, Side, UserBoundsList};
+use crate::bounds::{BoundOrFiller, BoundsType, UserBoundsList};
 use crate::finders::common::DelimiterFinder;
 use crate::options::{EOL, Opt, Trim};
 use crate::plan::FieldPlan;
@@ -216,7 +216,7 @@ where
         // (are there ranges in the first place?), since it's an
         // expensive operation.
         if bounds.iter().any(|bof| match bof {
-            BoundOrFiller::Bound(b) => b.l() != b.r() || *b.l() == Side::Continue,
+            BoundOrFiller::Bound(b) => b.l() != b.r(),
             BoundOrFiller::Filler(_) => false,
         }) {
             _bounds = bounds.unpack(

--- a/src/fast_lane.rs
+++ b/src/fast_lane.rs
@@ -106,8 +106,8 @@ fn output_parts<W: Write>(
         let idx_start = fields[r.start];
         let idx_end = fields[r.end] - 1;
         &line[idx_start..idx_end]
-    } else if b.fallback_oob.is_some() {
-        b.fallback_oob.as_ref().unwrap()
+    } else if b.fallback_oob().is_some() {
+        b.fallback_oob().as_ref().unwrap()
     } else if let Some(generic_fallback) = opt.fallback_oob {
         generic_fallback
     } else {
@@ -117,7 +117,7 @@ fn output_parts<W: Write>(
     let field_to_print = output;
     stdout.write_all(field_to_print)?;
 
-    if opt.join && !b.is_last {
+    if opt.join && !b.is_last() {
         stdout.write_all(&[opt.delimiter])?;
     }
 

--- a/src/fast_lane.rs
+++ b/src/fast_lane.rs
@@ -53,7 +53,7 @@ fn cut_str_fast_lane<W: Write>(
 
         fields.push(i + 1);
 
-        if curr_field == last_interesting_field.abs_value() {
+        if curr_field == last_interesting_field.value_unchecked() {
             // We have no use for any other fields in this line
             break;
         }
@@ -64,8 +64,8 @@ fn cut_str_fast_lane<W: Write>(
         return Ok(());
     }
 
-    if last_interesting_field.abs_value() == usize::MAX
-        || curr_field != last_interesting_field.abs_value()
+    if last_interesting_field.value_unchecked() == usize::MAX
+        || curr_field != last_interesting_field.value_unchecked()
     {
         // We reached the end of the line but didn't find
         // every field the user wanted. Maybe they want

--- a/src/fast_lane.rs
+++ b/src/fast_lane.rs
@@ -53,7 +53,7 @@ fn cut_str_fast_lane<W: Write>(
 
         fields.push(i + 1);
 
-        if Side::Some(curr_field) == last_interesting_field {
+        if curr_field == last_interesting_field.abs_value() {
             // We have no use for any other fields in this line
             break;
         }
@@ -64,7 +64,7 @@ fn cut_str_fast_lane<W: Write>(
         return Ok(());
     }
 
-    if Side::Some(curr_field) != last_interesting_field {
+    if curr_field != last_interesting_field.abs_value() {
         // We reached the end of the line. Who knows, maybe
         // the user is interested in this field too.
 

--- a/src/fast_lane.rs
+++ b/src/fast_lane.rs
@@ -64,7 +64,7 @@ fn cut_str_fast_lane<W: Write>(
         return Ok(());
     }
 
-    if last_interesting_field.value_unchecked() == Side::max_right()
+    if last_interesting_field.value_unchecked() == usize::MAX
         || curr_field != last_interesting_field.value_unchecked()
     {
         // We reached the end of the line but didn't find

--- a/src/fast_lane.rs
+++ b/src/fast_lane.rs
@@ -64,7 +64,7 @@ fn cut_str_fast_lane<W: Write>(
         return Ok(());
     }
 
-    if last_interesting_field.value_unchecked() == usize::MAX
+    if last_interesting_field.value_unchecked() == Side::max_right()
         || curr_field != last_interesting_field.value_unchecked()
     {
         // We reached the end of the line but didn't find

--- a/src/finders/regex.rs
+++ b/src/finders/regex.rs
@@ -20,6 +20,7 @@ impl RegexFinder {
 impl DelimiterFinder for RegexFinder {
     type Iter<'a> = Box<dyn Iterator<Item = Range<usize>> + 'a>;
 
+    #[inline(always)]
     fn find_ranges<'a>(&'a self, line: &'a [u8]) -> Self::Iter<'a> {
         if self.trim_empty {
             let line_len = line.len();

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -162,10 +162,11 @@ where
             self.get_field_bound(r)?.end
         };
 
-        if end < start {
+        if end >= start {
+            Ok(start..end)
+        } else {
             bail!("Field left value cannot be greater than right value");
         }
-        Ok(start..end)
     }
 }
 

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -113,8 +113,8 @@ where
             negative_indices,
             // XXX maybe I can reduce the capacity here
             // by storing fields by original index position?
-            positive_fields: vec![Side::max_right()..Side::max_right(); max_field_to_search_pos], // initialize with empty ranges
-            negative_fields: vec![Side::max_right()..Side::max_right(); max_field_to_search_neg], // initialize with empty ranges,
+            positive_fields: vec![usize::MAX..usize::MAX; max_field_to_search_pos], // initialize with empty ranges
+            negative_fields: vec![usize::MAX..usize::MAX; max_field_to_search_neg], // initialize with empty ranges,
             extract_func,
             finder,
             finder_rev,
@@ -137,9 +137,7 @@ where
         }
 
         if let Some(field) = fields.get(index)
-        // Field can start at max_right when the fields
-        // array is initialized that way.
-         && field.start != Side::max_right()
+        // WIP can field start every be eq max_right?
         {
             Ok(field)
         } else {
@@ -204,8 +202,8 @@ where
             .nth(desired_field - seen)
             .ok_or_else(|| {
                 plan.positive_fields[desired_field..].fill(Range {
-                    start: Side::max_right(),
-                    end: Side::max_right(),
+                    start: usize::MAX,
+                    end: usize::MAX,
                 });
                 anyhow::anyhow!("Out of bounds: {}", desired_field + 1)
             })?
@@ -256,8 +254,8 @@ where
             .nth(desired_field - seen)
             .ok_or_else(|| {
                 plan.negative_fields[desired_field..].fill(Range {
-                    start: Side::max_right(),
-                    end: Side::max_right(),
+                    start: usize::MAX,
+                    end: usize::MAX,
                 });
                 anyhow::anyhow!("Out of bounds: -{}", desired_field + 1)
             })?
@@ -327,8 +325,8 @@ where
 
         if num_fields < desired_field + 1 {
             plan.negative_fields[desired_field..].fill(Range {
-                start: Side::max_right(),
-                end: Side::max_right(),
+                start: usize::MAX,
+                end: usize::MAX,
             });
             out_of_bound_neg_idx = Some(desired_field);
             break;
@@ -540,7 +538,7 @@ mod tests {
         let expected_pos_indices = vec![0];
         let expected_neg_indices = vec![0];
         #[allow(clippy::single_range_in_vec_init)]
-        let expected_ranges = vec![Side::max_right()..Side::max_right()];
+        let expected_ranges = vec![usize::MAX..usize::MAX];
 
         let mut plan = FieldPlan::from_opt_fixed(&opt).unwrap();
         assert_eq!(plan.positive_indices, expected_pos_indices);
@@ -569,7 +567,7 @@ mod tests {
 
         let line = b"a-b-c-d-e";
         let expected_indices = vec![0, 1, 3];
-        let expected_ranges = vec![0..1, 2..3, Side::max_right()..Side::max_right(), 6..7];
+        let expected_ranges = vec![0..1, 2..3, usize::MAX..usize::MAX, 6..7];
 
         let mut plan = FieldPlan::from_opt_fixed(&opt).unwrap();
         assert_eq!(plan.positive_indices, expected_indices);
@@ -606,44 +604,26 @@ mod tests {
         assert_eq!(plan.positive_indices, expected_pos_indices);
 
         extract_fields_using_pos_indices(line1, &mut plan).unwrap();
-        assert_eq!(
-            plan.positive_fields,
-            vec![Side::max_right()..Side::max_right(), 2..3]
-        );
+        assert_eq!(plan.positive_fields, vec![usize::MAX..usize::MAX, 2..3]);
 
         extract_fields_using_pos_indices(line2, &mut plan).unwrap();
-        assert_eq!(
-            plan.positive_fields,
-            vec![Side::max_right()..Side::max_right(), 4..7]
-        );
+        assert_eq!(plan.positive_fields, vec![usize::MAX..usize::MAX, 4..7]);
 
         extract_fields_using_pos_indices(line3, &mut plan).unwrap();
-        assert_eq!(
-            plan.positive_fields,
-            vec![Side::max_right()..Side::max_right(), 5..10]
-        );
+        assert_eq!(plan.positive_fields, vec![usize::MAX..usize::MAX, 5..10]);
 
         // from_opt_fixed_greedy
         let mut plan = FieldPlan::from_opt_fixed_greedy(&opt).unwrap();
         assert_eq!(plan.positive_indices, expected_pos_indices);
 
         extract_fields_using_pos_indices(line1, &mut plan).unwrap();
-        assert_eq!(
-            plan.positive_fields,
-            vec![Side::max_right()..Side::max_right(), 2..3]
-        );
+        assert_eq!(plan.positive_fields, vec![usize::MAX..usize::MAX, 2..3]);
 
         extract_fields_using_pos_indices(line2, &mut plan).unwrap();
-        assert_eq!(
-            plan.positive_fields,
-            vec![Side::max_right()..Side::max_right(), 4..7]
-        );
+        assert_eq!(plan.positive_fields, vec![usize::MAX..usize::MAX, 4..7]);
 
         extract_fields_using_pos_indices(line3, &mut plan).unwrap();
-        assert_eq!(
-            plan.positive_fields,
-            vec![Side::max_right()..Side::max_right(), 5..10]
-        );
+        assert_eq!(plan.positive_fields, vec![usize::MAX..usize::MAX, 5..10]);
     }
 
     #[test]
@@ -654,9 +634,9 @@ mod tests {
         let line = b"a-b-c-d-e";
         let expected_indices = vec![1, 3, 4];
         let expected_ranges = vec![
-            Side::max_right()..Side::max_right(),
+            usize::MAX..usize::MAX,
             6..7,
-            Side::max_right()..Side::max_right(),
+            usize::MAX..usize::MAX,
             2..3,
             0..1,
         ];
@@ -688,7 +668,7 @@ mod tests {
 
         let line = b"a--b--c";
         let expected_indices = vec![0, 2];
-        let expected_ranges = vec![0..1, Side::max_right()..Side::max_right(), 6..7];
+        let expected_ranges = vec![0..1, usize::MAX..usize::MAX, 6..7];
 
         let mut plan = FieldPlan::from_opt_fixed_greedy(&opt).unwrap();
         assert_eq!(plan.positive_indices, expected_indices);
@@ -703,7 +683,7 @@ mod tests {
 
         let line = b"a--b--c";
         let expected_indices = vec![0, 2];
-        let expected_ranges = vec![6..7, Side::max_right()..Side::max_right(), 0..1];
+        let expected_ranges = vec![6..7, usize::MAX..usize::MAX, 0..1];
 
         let mut plan = FieldPlan::from_opt_fixed_greedy(&opt).unwrap();
         assert_eq!(plan.negative_indices, expected_indices);
@@ -720,7 +700,7 @@ mod tests {
         let expected_pos_indices = vec![0, 2];
         let expected_neg_indices = vec![0, 2];
         let expected_pos_ranges = vec![0..1, 2..3, 4..5, 6..7];
-        let expected_neg_ranges = vec![6..7, Side::max_right()..Side::max_right(), 2..3];
+        let expected_neg_ranges = vec![6..7, usize::MAX..usize::MAX, 2..3];
 
         let mut plan = FieldPlan::from_opt_fixed(&opt).unwrap();
         assert_eq!(plan.positive_indices, expected_pos_indices);
@@ -748,7 +728,7 @@ mod tests {
         extract_fields_using_pos_indices(line1, &mut plan).unwrap();
         assert_eq!(
             plan.positive_fields,
-            vec![Side::max_right()..Side::max_right(), 2..3, 4..5]
+            vec![usize::MAX..usize::MAX, 2..3, 4..5]
         );
 
         let res = extract_fields_using_pos_indices(line2, &mut plan);
@@ -756,16 +736,16 @@ mod tests {
         assert_eq!(
             plan.positive_fields,
             vec![
-                Side::max_right()..Side::max_right(),
-                Side::max_right()..Side::max_right(),
-                Side::max_right()..Side::max_right()
+                usize::MAX..usize::MAX,
+                usize::MAX..usize::MAX,
+                usize::MAX..usize::MAX
             ]
         );
 
         extract_fields_using_pos_indices(line3, &mut plan).unwrap();
         assert_eq!(
             plan.positive_fields,
-            vec![Side::max_right()..Side::max_right(), 5..10, 11..16]
+            vec![usize::MAX..usize::MAX, 5..10, 11..16]
         );
     }
 
@@ -786,7 +766,7 @@ mod tests {
         extract_fields_using_negative_indices(line1, &mut plan).unwrap();
         assert_eq!(
             plan.negative_fields,
-            vec![Side::max_right()..Side::max_right(), 2..3, 0..1]
+            vec![usize::MAX..usize::MAX, 2..3, 0..1]
         );
 
         let res = extract_fields_using_negative_indices(line2, &mut plan);
@@ -794,16 +774,16 @@ mod tests {
         assert_eq!(
             plan.negative_fields,
             vec![
-                Side::max_right()..Side::max_right(),
-                Side::max_right()..Side::max_right(),
-                Side::max_right()..Side::max_right()
+                usize::MAX..usize::MAX,
+                usize::MAX..usize::MAX,
+                usize::MAX..usize::MAX
             ]
         );
 
         extract_fields_using_negative_indices(line3, &mut plan).unwrap();
         assert_eq!(
             plan.negative_fields,
-            vec![Side::max_right()..Side::max_right(), 5..10, 0..4]
+            vec![usize::MAX..usize::MAX, 5..10, 0..4]
         );
     }
 
@@ -863,7 +843,7 @@ mod tests {
         assert_eq!(plan.positive_fields, vec![0..1, 2..3, 4..5]);
         assert_eq!(
             plan.negative_fields,
-            vec![Side::max_right()..Side::max_right(), 2..3, 0..1]
+            vec![usize::MAX..usize::MAX, 2..3, 0..1]
         );
 
         let res = extract_every_field(line2, &mut plan);
@@ -876,9 +856,9 @@ mod tests {
         assert_eq!(
             plan.negative_fields,
             vec![
-                Side::max_right()..Side::max_right(),
-                Side::max_right()..Side::max_right(),
-                Side::max_right()..Side::max_right()
+                usize::MAX..usize::MAX,
+                usize::MAX..usize::MAX,
+                usize::MAX..usize::MAX
             ]
         );
 
@@ -886,7 +866,7 @@ mod tests {
         assert_eq!(plan.positive_fields, vec![0..4, 5..10, 11..16]);
         assert_eq!(
             plan.negative_fields,
-            vec![Side::max_right()..Side::max_right(), 5..10, 0..4]
+            vec![usize::MAX..usize::MAX, 5..10, 0..4]
         );
     }
 

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -411,7 +411,7 @@ mod tests {
         opt.delimiter = "--".into();
         opt.bounds = UserBoundsList {
             list: Vec::new(),
-            last_interesting_field: Side::new_inf_right(),
+            last_interesting_field: Side::with_pos_inf(),
         };
 
         let maybe_plan = FieldPlan::from_opt_fixed(&opt);

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -58,7 +58,7 @@ where
         // First collect all indices from bounds, keeping duplicates and original order.
         for bof in opt.bounds.iter() {
             if let BoundOrFiller::Bound(b) = bof {
-                let left_value_0idx = b.l().abs_value();
+                let left_value_0idx = b.l().value_unchecked();
 
                 if b.l().is_negative() {
                     negative_indices.push(left_value_0idx);
@@ -68,11 +68,11 @@ where
 
                 if b.r().is_negative() {
                     // XXX can negative ever be max_right?
-                    if b.r().abs_value() != Side::max_right() {
-                        negative_indices.push(b.r().abs_value());
+                    if b.r().value_unchecked() != Side::max_right() {
+                        negative_indices.push(b.r().value_unchecked());
                     } // else ignore "continue" as right bound
-                } else if b.r().abs_value() != Side::max_right() {
-                    positive_indices.push(b.r().abs_value());
+                } else if b.r().value_unchecked() != Side::max_right() {
+                    positive_indices.push(b.r().value_unchecked());
                 }
             }
         }
@@ -129,7 +129,7 @@ where
             &self.positive_fields
         };
 
-        let index = side_val.abs_value();
+        let index = side_val.value_unchecked();
 
         if index >= fields.len() {
             return Err(anyhow::anyhow!("Out of bounds: {}", side_val));
@@ -155,7 +155,7 @@ where
 
         let end = if l == r {
             l_bound.end
-        } else if r.abs_value() == Side::max_right() {
+        } else if r.value_unchecked() == Side::max_right() {
             line_len
         } else {
             self.get_field_bound(r)?.end

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -317,7 +317,12 @@ where
     // Do we have any positive out of bounds?
     if plan.positive_indices.last() > Some(&(num_fields - 1)) {
         // need to find out which one is the first index out of bound
-        out_of_bound_pos_idx = plan.positive_indices.iter().find(|x| **x > num_fields - 1);
+        out_of_bound_pos_idx = Some(
+            plan.positive_indices
+                .binary_search(&(num_fields))
+                .unwrap_or_else(|idx| idx)
+                + 1, // wouldn't work for empty positive indices but here's ok
+        );
     }
 
     let mut out_of_bound_neg_idx = None;

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -146,6 +146,7 @@ where
         }
     }
 
+    #[inline(always)]
     pub fn get_field(&self, b: &UserBounds, line_len: usize) -> Result<Range<usize>> {
         let l = b.l();
         let r = b.r();

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -137,7 +137,9 @@ where
         }
 
         if let Some(field) = fields.get(index)
-        // WIP can field start every be eq max_right?
+        // Field can start at max_right when the fields
+        // array is initialized that way.
+         && field.start != Side::max_right()
         {
             Ok(field)
         } else {

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -58,7 +58,7 @@ where
         // First collect all indices from bounds, keeping duplicates and original order.
         for bof in opt.bounds.iter() {
             if let BoundOrFiller::Bound(b) = bof {
-                let left_value_0idx = b.l().abs_value() - 1;
+                let left_value_0idx = b.l().abs_value();
 
                 if b.l().is_negative() {
                     negative_indices.push(left_value_0idx);
@@ -69,10 +69,10 @@ where
                 if b.r().is_negative() {
                     // XXX can negative ever be max_right?
                     if b.r().abs_value() != Side::max_right() {
-                        negative_indices.push(b.r().abs_value() - 1);
+                        negative_indices.push(b.r().abs_value());
                     } // else ignore "continue" as right bound
                 } else if b.r().abs_value() != Side::max_right() {
-                    positive_indices.push(b.r().abs_value() - 1);
+                    positive_indices.push(b.r().abs_value());
                 }
             }
         }
@@ -129,7 +129,7 @@ where
             &self.positive_fields
         };
 
-        let index = side_val.abs_value() - 1;
+        let index = side_val.abs_value();
 
         if index >= fields.len() {
             return Err(anyhow::anyhow!("Out of bounds: {}", side_val));

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -58,12 +58,12 @@ where
         // First collect all indices from bounds, keeping duplicates and original order.
         for bof in opt.bounds.iter() {
             if let BoundOrFiller::Bound(b) = bof {
-                indices.push(match b.l {
+                indices.push(match *b.l() {
                     Side::Some(l) => l,
                     Side::Continue => 1,
                 });
 
-                if let Side::Some(r) = b.r {
+                if let Side::Some(r) = *b.r() {
                     indices.push(r);
                 } // else ignore "continue" as right bound
             }
@@ -159,7 +159,7 @@ where
     }
 
     pub fn get_field(&self, b: &UserBounds, line_len: usize) -> Result<Range<usize>> {
-        let (start, end) = match (b.l, b.r) {
+        let (start, end) = match (*b.l(), *b.r()) {
             (Side::Some(l), Side::Some(r)) => {
                 // Process both at once to potentially reuse field array access
                 let start_field = self.get_field_bound(l)?;

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -113,8 +113,8 @@ where
             negative_indices,
             // XXX maybe I can reduce the capacity here
             // by storing fields by original index position?
-            positive_fields: vec![usize::MAX..usize::MAX; max_field_to_search_pos], // initialize with empty ranges
-            negative_fields: vec![usize::MAX..usize::MAX; max_field_to_search_neg], // initialize with empty ranges,
+            positive_fields: vec![Side::max_right()..Side::max_right(); max_field_to_search_pos], // initialize with empty ranges
+            negative_fields: vec![Side::max_right()..Side::max_right(); max_field_to_search_neg], // initialize with empty ranges,
             extract_func,
             finder,
             finder_rev,
@@ -204,8 +204,8 @@ where
             .nth(desired_field - seen)
             .ok_or_else(|| {
                 plan.positive_fields[desired_field..].fill(Range {
-                    start: usize::MAX,
-                    end: usize::MAX,
+                    start: Side::max_right(),
+                    end: Side::max_right(),
                 });
                 anyhow::anyhow!("Out of bounds: {}", desired_field + 1)
             })?
@@ -256,8 +256,8 @@ where
             .nth(desired_field - seen)
             .ok_or_else(|| {
                 plan.negative_fields[desired_field..].fill(Range {
-                    start: usize::MAX,
-                    end: usize::MAX,
+                    start: Side::max_right(),
+                    end: Side::max_right(),
                 });
                 anyhow::anyhow!("Out of bounds: -{}", desired_field + 1)
             })?
@@ -327,8 +327,8 @@ where
 
         if num_fields < desired_field + 1 {
             plan.negative_fields[desired_field..].fill(Range {
-                start: usize::MAX,
-                end: usize::MAX,
+                start: Side::max_right(),
+                end: Side::max_right(),
             });
             out_of_bound_neg_idx = Some(desired_field);
             break;
@@ -540,7 +540,7 @@ mod tests {
         let expected_pos_indices = vec![0];
         let expected_neg_indices = vec![0];
         #[allow(clippy::single_range_in_vec_init)]
-        let expected_ranges = vec![usize::MAX..usize::MAX];
+        let expected_ranges = vec![Side::max_right()..Side::max_right()];
 
         let mut plan = FieldPlan::from_opt_fixed(&opt).unwrap();
         assert_eq!(plan.positive_indices, expected_pos_indices);
@@ -569,7 +569,7 @@ mod tests {
 
         let line = b"a-b-c-d-e";
         let expected_indices = vec![0, 1, 3];
-        let expected_ranges = vec![0..1, 2..3, usize::MAX..usize::MAX, 6..7];
+        let expected_ranges = vec![0..1, 2..3, Side::max_right()..Side::max_right(), 6..7];
 
         let mut plan = FieldPlan::from_opt_fixed(&opt).unwrap();
         assert_eq!(plan.positive_indices, expected_indices);
@@ -606,26 +606,44 @@ mod tests {
         assert_eq!(plan.positive_indices, expected_pos_indices);
 
         extract_fields_using_pos_indices(line1, &mut plan).unwrap();
-        assert_eq!(plan.positive_fields, vec![usize::MAX..usize::MAX, 2..3]);
+        assert_eq!(
+            plan.positive_fields,
+            vec![Side::max_right()..Side::max_right(), 2..3]
+        );
 
         extract_fields_using_pos_indices(line2, &mut plan).unwrap();
-        assert_eq!(plan.positive_fields, vec![usize::MAX..usize::MAX, 4..7]);
+        assert_eq!(
+            plan.positive_fields,
+            vec![Side::max_right()..Side::max_right(), 4..7]
+        );
 
         extract_fields_using_pos_indices(line3, &mut plan).unwrap();
-        assert_eq!(plan.positive_fields, vec![usize::MAX..usize::MAX, 5..10]);
+        assert_eq!(
+            plan.positive_fields,
+            vec![Side::max_right()..Side::max_right(), 5..10]
+        );
 
         // from_opt_fixed_greedy
         let mut plan = FieldPlan::from_opt_fixed_greedy(&opt).unwrap();
         assert_eq!(plan.positive_indices, expected_pos_indices);
 
         extract_fields_using_pos_indices(line1, &mut plan).unwrap();
-        assert_eq!(plan.positive_fields, vec![usize::MAX..usize::MAX, 2..3]);
+        assert_eq!(
+            plan.positive_fields,
+            vec![Side::max_right()..Side::max_right(), 2..3]
+        );
 
         extract_fields_using_pos_indices(line2, &mut plan).unwrap();
-        assert_eq!(plan.positive_fields, vec![usize::MAX..usize::MAX, 4..7]);
+        assert_eq!(
+            plan.positive_fields,
+            vec![Side::max_right()..Side::max_right(), 4..7]
+        );
 
         extract_fields_using_pos_indices(line3, &mut plan).unwrap();
-        assert_eq!(plan.positive_fields, vec![usize::MAX..usize::MAX, 5..10]);
+        assert_eq!(
+            plan.positive_fields,
+            vec![Side::max_right()..Side::max_right(), 5..10]
+        );
     }
 
     #[test]
@@ -636,9 +654,9 @@ mod tests {
         let line = b"a-b-c-d-e";
         let expected_indices = vec![1, 3, 4];
         let expected_ranges = vec![
-            usize::MAX..usize::MAX,
+            Side::max_right()..Side::max_right(),
             6..7,
-            usize::MAX..usize::MAX,
+            Side::max_right()..Side::max_right(),
             2..3,
             0..1,
         ];
@@ -670,7 +688,7 @@ mod tests {
 
         let line = b"a--b--c";
         let expected_indices = vec![0, 2];
-        let expected_ranges = vec![0..1, usize::MAX..usize::MAX, 6..7];
+        let expected_ranges = vec![0..1, Side::max_right()..Side::max_right(), 6..7];
 
         let mut plan = FieldPlan::from_opt_fixed_greedy(&opt).unwrap();
         assert_eq!(plan.positive_indices, expected_indices);
@@ -685,7 +703,7 @@ mod tests {
 
         let line = b"a--b--c";
         let expected_indices = vec![0, 2];
-        let expected_ranges = vec![6..7, usize::MAX..usize::MAX, 0..1];
+        let expected_ranges = vec![6..7, Side::max_right()..Side::max_right(), 0..1];
 
         let mut plan = FieldPlan::from_opt_fixed_greedy(&opt).unwrap();
         assert_eq!(plan.negative_indices, expected_indices);
@@ -702,7 +720,7 @@ mod tests {
         let expected_pos_indices = vec![0, 2];
         let expected_neg_indices = vec![0, 2];
         let expected_pos_ranges = vec![0..1, 2..3, 4..5, 6..7];
-        let expected_neg_ranges = vec![6..7, usize::MAX..usize::MAX, 2..3];
+        let expected_neg_ranges = vec![6..7, Side::max_right()..Side::max_right(), 2..3];
 
         let mut plan = FieldPlan::from_opt_fixed(&opt).unwrap();
         assert_eq!(plan.positive_indices, expected_pos_indices);
@@ -730,7 +748,7 @@ mod tests {
         extract_fields_using_pos_indices(line1, &mut plan).unwrap();
         assert_eq!(
             plan.positive_fields,
-            vec![usize::MAX..usize::MAX, 2..3, 4..5]
+            vec![Side::max_right()..Side::max_right(), 2..3, 4..5]
         );
 
         let res = extract_fields_using_pos_indices(line2, &mut plan);
@@ -738,16 +756,16 @@ mod tests {
         assert_eq!(
             plan.positive_fields,
             vec![
-                usize::MAX..usize::MAX,
-                usize::MAX..usize::MAX,
-                usize::MAX..usize::MAX
+                Side::max_right()..Side::max_right(),
+                Side::max_right()..Side::max_right(),
+                Side::max_right()..Side::max_right()
             ]
         );
 
         extract_fields_using_pos_indices(line3, &mut plan).unwrap();
         assert_eq!(
             plan.positive_fields,
-            vec![usize::MAX..usize::MAX, 5..10, 11..16]
+            vec![Side::max_right()..Side::max_right(), 5..10, 11..16]
         );
     }
 
@@ -768,7 +786,7 @@ mod tests {
         extract_fields_using_negative_indices(line1, &mut plan).unwrap();
         assert_eq!(
             plan.negative_fields,
-            vec![usize::MAX..usize::MAX, 2..3, 0..1]
+            vec![Side::max_right()..Side::max_right(), 2..3, 0..1]
         );
 
         let res = extract_fields_using_negative_indices(line2, &mut plan);
@@ -776,16 +794,16 @@ mod tests {
         assert_eq!(
             plan.negative_fields,
             vec![
-                usize::MAX..usize::MAX,
-                usize::MAX..usize::MAX,
-                usize::MAX..usize::MAX
+                Side::max_right()..Side::max_right(),
+                Side::max_right()..Side::max_right(),
+                Side::max_right()..Side::max_right()
             ]
         );
 
         extract_fields_using_negative_indices(line3, &mut plan).unwrap();
         assert_eq!(
             plan.negative_fields,
-            vec![usize::MAX..usize::MAX, 5..10, 0..4]
+            vec![Side::max_right()..Side::max_right(), 5..10, 0..4]
         );
     }
 
@@ -845,7 +863,7 @@ mod tests {
         assert_eq!(plan.positive_fields, vec![0..1, 2..3, 4..5]);
         assert_eq!(
             plan.negative_fields,
-            vec![usize::MAX..usize::MAX, 2..3, 0..1]
+            vec![Side::max_right()..Side::max_right(), 2..3, 0..1]
         );
 
         let res = extract_every_field(line2, &mut plan);
@@ -858,9 +876,9 @@ mod tests {
         assert_eq!(
             plan.negative_fields,
             vec![
-                usize::MAX..usize::MAX,
-                usize::MAX..usize::MAX,
-                usize::MAX..usize::MAX
+                Side::max_right()..Side::max_right(),
+                Side::max_right()..Side::max_right(),
+                Side::max_right()..Side::max_right()
             ]
         );
 
@@ -868,7 +886,7 @@ mod tests {
         assert_eq!(plan.positive_fields, vec![0..4, 5..10, 11..16]);
         assert_eq!(
             plan.negative_fields,
-            vec![usize::MAX..usize::MAX, 5..10, 0..4]
+            vec![Side::max_right()..Side::max_right(), 5..10, 0..4]
         );
     }
 

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -58,21 +58,22 @@ where
         // First collect all indices from bounds, keeping duplicates and original order.
         for bof in opt.bounds.iter() {
             if let BoundOrFiller::Bound(b) = bof {
-                let left_value_0idx = b.l().value_unchecked();
+                let (l_is_negative, l_value) = b.l().value();
+                let (r_is_negative, r_value) = b.r().value();
 
-                if b.l().is_negative() {
-                    negative_indices.push(left_value_0idx);
+                if l_is_negative {
+                    negative_indices.push(l_value);
                 } else {
-                    positive_indices.push(left_value_0idx);
+                    positive_indices.push(l_value);
                 }
 
-                if b.r().is_negative() {
+                if r_is_negative {
                     // XXX can negative ever be max_right?
-                    if b.r().value_unchecked() != Side::max_right() {
-                        negative_indices.push(b.r().value_unchecked());
+                    if r_value != Side::max_right() {
+                        negative_indices.push(r_value);
                     } // else ignore "continue" as right bound
-                } else if b.r().value_unchecked() != Side::max_right() {
-                    positive_indices.push(b.r().value_unchecked());
+                } else if r_value != Side::max_right() {
+                    positive_indices.push(r_value);
                 }
             }
         }

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -137,7 +137,6 @@ where
         }
 
         if let Some(field) = fields.get(index)
-            && field.start != Side::max_right()
         // WIP can field start every be eq max_right?
         {
             Ok(field)

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -23,13 +23,13 @@ impl TryFrom<&UserBoundsList> for ForwardBounds {
         if value.is_empty() {
             Err("Cannot create ForwardBounds from an empty UserBoundsList")
         } else if value.is_forward_only() {
-            let mut prev_bound_idx = Side::Some(0);
+            let mut prev_bound_idx = 0;
             value.iter().try_for_each(|bof| {
                 if let BoundOrFiller::Bound(b) = bof {
-                    if *b.l() == prev_bound_idx {
+                    if b.l().abs_value() == prev_bound_idx {
                         return Err("Bounds are sorted, but can't be repeated");
                     }
-                    prev_bound_idx = *b.l();
+                    prev_bound_idx = b.l().abs_value();
                 }
                 Ok(())
             })?;
@@ -181,7 +181,7 @@ fn print_bof<W: Write>(
     stdout: &mut W,
     opt: &StreamOpt,
     bof_idx: usize,
-    curr_field: i32,
+    curr_field: usize,
     chunk: &[u8],
     prev_chunk_idx: usize,
     chunk_idx: usize,
@@ -200,7 +200,7 @@ fn print_bof<W: Write>(
         if b.matches(curr_field).unwrap() {
             let prepend_delimiter = !prev_chunk_may_be_truncated
                 && curr_field > 1
-                && (opt.join || (*b.l() != Side::Some(curr_field)));
+                && (opt.join || (b.l().abs_value() != curr_field));
 
             let delimiter = opt.replace_delimiter.unwrap_or(opt.delimiter);
 
@@ -211,7 +211,7 @@ fn print_bof<W: Write>(
                 prepend_delimiter,
             )?;
 
-            if *b.r() == Side::Some(curr_field) {
+            if b.r().abs_value() == curr_field {
                 bof_idx += 1;
             }
         }
@@ -239,7 +239,7 @@ fn print_filler_or_fallbacks<W: Write>(
             BoundOrFiller::Bound(b) => b,
         };
 
-        if *b.r() == Side::Continue {
+        if b.r().abs_value() == Side::max_right() {
             break;
         }
 
@@ -320,7 +320,7 @@ fn cut_bytes_stream<R: BufRead, W: Write>(
                 }
 
                 // If we've found the last field we're interested in
-                if Side::Some(curr_field) == last_interesting_field {
+                if curr_field == last_interesting_field.abs_value() {
                     // Print any remaining fillers (no fallbacks, since we're done with the fields)
                     print_filler_or_fallbacks(stdout, bof_idx, opt)?;
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -26,10 +26,10 @@ impl TryFrom<&UserBoundsList> for ForwardBounds {
             let mut prev_bound_idx = usize::MAX;
             value.iter().try_for_each(|bof| {
                 if let BoundOrFiller::Bound(b) = bof {
-                    if b.l().abs_value() == prev_bound_idx {
+                    if b.l().value_unchecked() == prev_bound_idx {
                         return Err("Bounds are sorted, but can't be repeated");
                     }
-                    prev_bound_idx = b.l().abs_value();
+                    prev_bound_idx = b.l().value_unchecked();
                 }
                 Ok(())
             })?;
@@ -200,7 +200,7 @@ fn print_bof<W: Write>(
         if b.matches(curr_field).unwrap() {
             let prepend_delimiter = !prev_chunk_may_be_truncated
                 && curr_field > 0
-                && (opt.join || (b.l().abs_value() != curr_field));
+                && (opt.join || (b.l().value_unchecked() != curr_field));
 
             let delimiter = opt.replace_delimiter.unwrap_or(opt.delimiter);
 
@@ -211,7 +211,7 @@ fn print_bof<W: Write>(
                 prepend_delimiter,
             )?;
 
-            if b.r().abs_value() == curr_field {
+            if b.r().value_unchecked() == curr_field {
                 bof_idx += 1;
             }
         }
@@ -239,7 +239,7 @@ fn print_filler_or_fallbacks<W: Write>(
             BoundOrFiller::Bound(b) => b,
         };
 
-        if b.r().abs_value() == Side::max_right() {
+        if b.r().value_unchecked() == Side::max_right() {
             break;
         }
 
@@ -320,7 +320,7 @@ fn cut_bytes_stream<R: BufRead, W: Write>(
                 }
 
                 // If we've found the last field we're interested in
-                if curr_field == last_interesting_field.abs_value() {
+                if curr_field == last_interesting_field.value_unchecked() {
                     // Print any remaining fillers (no fallbacks, since we're done with the fields)
                     print_filler_or_fallbacks(stdout, bof_idx, opt)?;
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -23,7 +23,7 @@ impl TryFrom<&UserBoundsList> for ForwardBounds {
         if value.is_empty() {
             Err("Cannot create ForwardBounds from an empty UserBoundsList")
         } else if value.is_forward_only() {
-            let mut prev_bound_idx = 0;
+            let mut prev_bound_idx = usize::MAX;
             value.iter().try_for_each(|bof| {
                 if let BoundOrFiller::Bound(b) = bof {
                     if b.l().abs_value() == prev_bound_idx {
@@ -199,7 +199,7 @@ fn print_bof<W: Write>(
         // field 4 but we are at field 2.
         if b.matches(curr_field).unwrap() {
             let prepend_delimiter = !prev_chunk_may_be_truncated
-                && curr_field > 1
+                && curr_field > 0
                 && (opt.join || (b.l().abs_value() != curr_field));
 
             let delimiter = opt.replace_delimiter.unwrap_or(opt.delimiter);
@@ -268,7 +268,7 @@ fn cut_bytes_stream<R: BufRead, W: Write>(
 
     'new_line: loop {
         let mut bof_idx = 0;
-        let mut curr_field = 1;
+        let mut curr_field = 0;
         let mut prev_chunk_may_be_truncated = false;
         let mut eol_reached = false;
         let mut empty_line = true;


### PR DESCRIPTION
Side is now accessed through implemented methods, which offers more wiggle room for future refactoring (maybe generics?).
Side contains zero-indexed values, so we can skip some arithmetic here and there (and de facto way more indexes, from i32 to usize, but that's hardly going to be used, maybe reading binaries...).


Despite the big changes the difference in performance (wall clock time) is minimal.
Overall, fewer instructions, fewer L1 cache miss, minimally better branch prediction


```=== Performance Comparison ===

=== tuc-master ===

 Performance counter stats for 'taskset -c 1 ./tuc-master -d    -f 2,-2 /tmp/data-multichar.txt' (10 runs):

     5,518,124,703      cycles:u                                                                ( +-  2.98% )  (39.94%)
    12,605,719,278      instructions:u                   #    2.28  insn per cycle
                                                  #    0.01  stalled cycles per insn     ( +-  0.05% )  (39.93%)
     4,421,387,714      L1-dcache-loads:u                                                       ( +-  0.20% )  (39.94%)
        11,564,142      L1-dcache-load-misses:u          #    0.26% of all L1-dcache accesses   ( +-  3.36% )  (39.96%)
         3,276,799      L1-icache-load-misses:u                                                 ( +-  3.29% )  (40.00%)
         2,940,505      dTLB-loads:u                                                            ( +-  0.12% )  (40.03%)
         2,749,414      dTLB-load-misses:u               #   93.50% of all dTLB cache accesses  ( +-  0.09% )  (40.04%)
             4,740      iTLB-loads:u                                                            ( +-  3.71% )  (40.05%)
             6,468      iTLB-load-misses:u               #  136.46% of all iTLB cache accesses  ( +-  4.23% )  (40.04%)
     2,605,332,603      branches:u                                                              ( +-  0.05% )  (40.04%)
        10,553,217      branch-misses:u                  #    0.41% of all branches             ( +-  0.78% )  (40.04%)
        97,896,460      stalled-cycles-frontend:u        #    1.77% frontend cycles idle        ( +- 14.86% )  (40.04%)
       105,549,553      stalled-cycles-backend:u         #    1.91% backend cycles idle         ( +- 11.01% )  (40.02%)
        23,464,926      cache-misses:u                   #   10.62% of all cache refs           ( +-  1.67% )  (39.98%)
       220,855,256      cache-references:u                                                      ( +-  0.78% )  (39.95%)

            2.8589 +- 0.0406 seconds time elapsed  ( +-  1.42% )

----------------------------------------

=== tuc-10933d3 ===

 Performance counter stats for 'taskset -c 1 ./tuc-10933d3 -d    -f 2,-2 /tmp/data-multichar.txt' (10 runs):

     5,389,054,568      cycles:u                                                                ( +-  0.19% )  (40.01%)
    12,502,447,571      instructions:u                   #    2.32  insn per cycle
                                                  #    0.01  stalled cycles per insn     ( +-  0.04% )  (40.01%)
     4,437,491,477      L1-dcache-loads:u                                                       ( +-  0.25% )  (40.01%)
        15,938,639      L1-dcache-load-misses:u          #    0.36% of all L1-dcache accesses   ( +- 27.76% )  (40.01%)
           903,479      L1-icache-load-misses:u                                                 ( +-  0.73% )  (40.00%)
         2,950,686      dTLB-loads:u                                                            ( +-  0.17% )  (40.01%)
         2,749,183      dTLB-load-misses:u               #   93.17% of all dTLB cache accesses  ( +-  0.08% )  (39.99%)
             6,003      iTLB-loads:u                                                            ( +-  3.81% )  (39.99%)
             5,822      iTLB-load-misses:u               #   96.98% of all iTLB cache accesses  ( +-  2.58% )  (39.99%)
     2,564,811,188      branches:u                                                              ( +-  0.03% )  (40.00%)
        10,267,471      branch-misses:u                  #    0.40% of all branches             ( +-  0.72% )  (40.00%)
        83,804,303      stalled-cycles-frontend:u        #    1.56% frontend cycles idle        ( +-  4.25% )  (39.99%)
       118,104,976      stalled-cycles-backend:u         #    2.19% backend cycles idle         ( +-  0.36% )  (40.00%)
        23,388,253      cache-misses:u                   #   10.57% of all cache refs           ( +-  1.46% )  (39.99%)
       221,263,948      cache-references:u                                                      ( +-  3.11% )  (39.99%)

           2.81932 +- 0.00194 seconds time elapsed  ( +-  0.07% )

----------------------------------------

=== Alternative: Focused Measurements ===
--- Core Execution ---
tuc-master:

 Performance counter stats for 'taskset -c 1 ./tuc-master -d    -f 2,-2 /tmp/data-multichar.txt' (10 runs):

     5,356,010,384      cycles:u                                                                ( +-  0.19% )
    12,614,350,891      instructions:u                   #    2.36  insn per cycle              ( +-  0.00% )
     2,604,224,490      branches:u                                                              ( +-  0.00% )
        10,829,364      branch-misses:u                  #    0.42% of all branches             ( +-  1.22% )

           2.80035 +- 0.00147 seconds time elapsed  ( +-  0.05% )


tuc-10933d3:

 Performance counter stats for 'taskset -c 1 ./tuc-10933d3 -d    -f 2,-2 /tmp/data-multichar.txt' (10 runs):

     5,373,427,610      cycles:u                                                                ( +-  0.30% )
    12,516,348,136      instructions:u                   #    2.33  insn per cycle              ( +-  0.00% )
     2,562,223,892      branches:u                                                              ( +-  0.00% )
        10,530,362      branch-misses:u                  #    0.41% of all branches             ( +-  1.10% )

           2.79172 +- 0.00371 seconds time elapsed  ( +-  0.13% )


--- Memory Hierarchy ---
tuc-master:

 Performance counter stats for 'taskset -c 1 ./tuc-master -d    -f 2,-2 /tmp/data-multichar.txt' (10 runs):

     4,428,202,965      L1-dcache-loads:u                                                       ( +-  0.05% )
        12,467,235      L1-dcache-load-misses:u          #    0.28% of all L1-dcache accesses   ( +- 10.38% )
       222,669,633      cache-references:u                                                      ( +-  0.75% )
        23,013,473      cache-misses:u                   #   10.34% of all cache refs           ( +-  0.40% )

          2.801282 +- 0.000530 seconds time elapsed  ( +-  0.02% )


tuc-10933d3:

 Performance counter stats for 'taskset -c 1 ./tuc-10933d3 -d    -f 2,-2 /tmp/data-multichar.txt' (10 runs):

     4,447,668,339      L1-dcache-loads:u                                                       ( +-  0.17% )
        10,393,877      L1-dcache-load-misses:u          #    0.23% of all L1-dcache accesses   ( +-  3.68% )
       214,839,870      cache-references:u                                                      ( +-  0.29% )
        23,072,819      cache-misses:u                   #   10.74% of all cache refs           ( +-  0.90% )

           2.80134 +- 0.00146 seconds time elapsed  ( +-  0.05% )


--- Pipeline Efficiency ---
tuc-master:

 Performance counter stats for 'taskset -c 1 ./tuc-master -d    -f 2,-2 /tmp/data-multichar.txt' (10 runs):

       101,718,499      stalled-cycles-frontend:u        #    1.91% frontend cycles idle        ( +-  6.74% )
       113,477,886      stalled-cycles-backend:u         #    2.13% backend cycles idle         ( +-  3.16% )
     5,333,206,750      cycles:u                                                                ( +-  0.26% )
    12,614,350,610      instructions:u                   #    2.37  insn per cycle
                                                  #    0.01  stalled cycles per insn     ( +-  0.00% )

           2.80065 +- 0.00150 seconds time elapsed  ( +-  0.05% )


tuc-10933d3:

 Performance counter stats for 'taskset -c 1 ./tuc-10933d3 -d    -f 2,-2 /tmp/data-multichar.txt' (10 runs):

        81,914,003      stalled-cycles-frontend:u        #    1.53% frontend cycles idle        ( +-  1.64% )
       118,855,012      stalled-cycles-backend:u         #    2.22% backend cycles idle         ( +-  0.11% )
     5,346,344,656      cycles:u                                                                ( +-  0.05% )
    12,516,348,264      instructions:u                   #    2.34  insn per cycle
                                                  #    0.01  stalled cycles per insn     ( +-  0.00% )

          2.803538 +- 0.000418 seconds time elapsed  ( +-  0.01% )

```